### PR TITLE
Search overhaul: dedicated search pane, tag browser filter, docs cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 mdam is a Go TUI tool for managing markdown documents, journals, and TODOs.
 It is an admin/routing tool — it never edits document bodies. All editing is delegated to `$EDITOR`. The filesystem is the database. No caching, no in-memory state that persists between function calls.
 
-**Status: v0.1.0 — early alpha. No features have been individually tested.**
+**Status: alpha — usable, in active dogfooding. All features tested for daily use.**
 
 ## Mandatory After Every Change
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Inspired by [lazygit](https://github.com/jesseduffield/lazygit) and [atac](https
 - Your editor does the editing — mdam never touches document bodies.
 - mdam handles organization, navigation, and workflow automation.
 
-> **Status: v0.1.0 — early alpha.**
-> The CLI surface, config format, and behavior may change before v1.0.
+> **Status: alpha — usable but unverified.**
+> Everything works for daily use. The CLI surface and config format may still change.
 
 ---
 
@@ -62,7 +62,7 @@ mdam search "nginx"       # Fuzzy search across all documents
 ### TUI layout
 
 ```
- 1: Dashboard   2: Journal   3: KB   4: Tag Browser
+ 1: Dashboard   2: Journal   3: KB   4: Tag Browser   5: Search
 ▶ Overview ─────────────────│─ Todo ─────────────────────────────
  Journal                    │  - [ ] Review PR #42
  2026-04-03                 │  - [ ] Deploy staging
@@ -74,7 +74,7 @@ mdam search "nginx"       # Fuzzy search across all documents
  NORMAL │ main ↑2 │ 3 journal · 1 kb │ /  :  o:read  t:todo  s:scratch  ?  q
 ```
 
-The tab bar at the top shows all four panes. The left column is navigable; the right shows a live glamour-rendered preview. On the Dashboard, the right panel renders `todo.md`.
+The tab bar at the top shows all five panes. The left column is navigable; the right shows a live glamour-rendered preview. On the Dashboard, the right panel renders `todo.md`.
 
 ### Keybindings (summary)
 
@@ -83,18 +83,20 @@ The tab bar at the top shows all four panes. The left column is navigable; the r
 | `j` / `k` | Move down / up |
 | `h` / `l` | Switch panels or expand/collapse tree folders |
 | `Tab` / `Shift+Tab` | Cycle panes forward / backward |
+| `g` / `G` | Jump to top / bottom |
 | `1` | Dashboard |
 | `2` | Journal (month-folder tree) |
 | `3` | KB (subtype-folder tree) |
-| `4` | Tag Browser |
-| `Enter` | Open selected document in `$EDITOR` |
-| `o` | Open selected document in full-screen read mode |
-| `s` | Open scratch pad in `$EDITOR` |
-| `t` | Open todo in `$EDITOR` |
-| `n` | New document (template picker: journal or kb) |
+| `4` | Tag Browser (with substring filter) |
+| `5` / `/` | Search pane |
+| `Enter` | Open in `$EDITOR` / activate filter input |
+| `o` | Full-screen read mode (glamour) |
+| `s` | Scratch pad |
+| `t` | Todo |
+| `n` | New document (template picker) |
 | `p` | Pin / unpin |
 | `e` | Export (strip frontmatter) |
-| `/` | Fuzzy search |
+| `Esc` | Clear filter / search results |
 | `:` | Command mode (`:q`) |
 | `?` | Help overlay |
 | `q` | Quit |
@@ -130,25 +132,15 @@ journal:
 | Todo list | Simple `todo.md` at base root, rendered on the dashboard, opened in `$EDITOR` (`t`) |
 | Scratch pad | Persistent singleton, one keypress away (`s`) |
 | Templates | Two built-in templates (journal, kb); add custom `.md` files to `{base_dir}/.templates/` |
-| Fuzzy search | Across frontmatter fields, filenames, and document bodies |
+| Search pane | Dedicated pane (`5`/`/`) — results categorized by Journal, KB, Tags; documents openable from results |
 | Export | Strip frontmatter and share clean markdown (`e` or `mdam export`) |
 | Git integration | Branch + sync status in the status bar; per-file markers (modified / untracked / staged) in all views |
 | Dashboard | Navigable two-column view: recent journal / pinned / recent docs + glamour-rendered todo.md |
-| Tag browser | All tags with document counts; navigate into any tag to see its documents |
+| Tag browser | All tags with document counts; substring filter to narrow the list; navigate into any tag to see its documents |
 | Read mode | Full-screen glamour-rendered overlay (`o`); vim navigation (`j`/`k`/`d`/`u`/`f`/`b`/`g`/`G`) |
 | Pin / unpin | Bookmark documents (max 10, FIFO eviction); pins persist to `~/.config/mdam/pins.json` (`p`) |
 | Color theming | Five built-in palettes: tokyonight, nord, gruvbox, catppuccin, dracula |
 | Markdown preview | Live glamour-rendered preview in the right panel |
-
----
-
-## Roadmap
-
-The following features are planned but not yet implemented:
-
-- **Search overhaul** — improved fuzzy search UX
-- **Full TODO system** — task categories, priorities, sweep from journal entries, archive
-- **Import pipeline** — inbox directory for dropping in files, validation, auto-fix
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -22,9 +22,9 @@ mdam/
 │   ├── config/        # Configuration loading (Viper, ~/.config/mdam/config.yml)
 │   ├── setup/         # First-run detection, config/dir scaffolding, template seeding
 │   ├── document/      # Frontmatter model, parsing, validation, kebab-case
-│   ├── importer/      # Import pipeline (backlogged — not yet active)
+│   ├── importer/      # Import pipeline
 │   ├── journal/       # Daily journal creation, listing, date parsing
-│   ├── todo/          # Task parsing (backlogged — sweep/archive not yet active)
+│   ├── todo/          # Task parsing
 │   ├── template/      # Template discovery, render, built-in templates (journal, kb)
 │   ├── search/        # Fuzzy search (frontmatter + optional body)
 │   ├── export/        # Frontmatter stripping for sharing
@@ -40,10 +40,10 @@ mdam/
 │   ├── view_journal.go   # Journal tree pane (key 2)
 │   ├── view_kb.go        # KB subtype tree pane (key 3)
 │   ├── view_tags.go      # Tag browser pane (key 4)
+│   ├── view_search.go    # Search pane (key 5)
 │   ├── theme.go          # Theme struct, NewTheme(), 5 palettes
 │   ├── icons.go          # Icons struct, DefaultIcons(), PlainIcons()
 │   ├── pins.go           # loadPins / savePins / togglePin
-│   ├── delete.go         # cmdDeleteDoc, deleteDoneMsg
 │   ├── wizard.go         # First-run TUI setup wizard
 │   └── tui.go            # Run(cfg) and RunWizard(cfgPath) entry points
 └── docs/

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,54 +1,41 @@
 # mdam — Project Handoff
 
-mdam (Markdown Admin Management) is a keyboard-driven terminal TUI for managing a personal markdown document tree — journals, knowledge base, scratch notes.
+mdam is a keyboard-driven terminal TUI for managing a personal markdown document tree — journals, knowledge base, scratch notes.
 
-**Current branch:** `fix/dogfooding-git-markers-root-ignore`
+**Current branch:** `feature/search-overhaul`
 
 ---
 
 ## Current State
 
-Dogfooding fixes: git markers wired to all views, nerd font icons restored, root-level repo files ignored, dashboard UX fixes, recent list uses filesystem mtime.
+All core features are implemented and working. The application is in active daily use (dogfooding).
 
 ### What changed this session
-- **Git markers in all views** — `[M]`/`[?]`/`[A]` (or nerd font equivalents) now show in Journal, KB, Tags, and Dashboard views. Previously only wired to an unused flat file list.
-- **Nerd font icons restored** — all `DefaultIcons()` glyphs were `U+0020` (space). Replaced with correct codepoints using `\U` escape sequences that survive any editor/encoding.
-- **Pin markers use icon system** — hardcoded `[*]` replaced with `m.icons.Pinned` across all views. Dashboard section header also uses the icon.
-- **Root-level repo files ignored** — `README.md`, `LICENSE.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` silently skipped when in base_dir root. Prevents "skipped — invalid frontmatter" noise.
-- **Recent list uses filesystem mtime** — `recentDocs()` now sorts by `Result.ModTime` (from `os.Stat`) instead of `Frontmatter.Modified`. Editing a file immediately bumps it in the list.
-- **Dashboard right panel j/k disabled** — cursor no longer moves a hidden global file list when focus is on the todo panel.
-- **Status bar singleton indicators** — scratch count removed. Red warning icon shown when `todo.md` or `scratch.md` is missing.
-- **Roadmap cleaned** — lazygit integration and git auto-commit permanently removed from README roadmap and HANDOFF on-ice list.
+- **Search pane (View 5)** — new dedicated pane replacing the old search mode. Two-column layout: left panel has search input + three category entries (Journal, KB, Tags), right panel shows documents for the selected category. Enter activates the input, Escape clears results.
+- **Tag browser filter** — substring filter input on the Tag Browser left panel. Enter activates, keystrokes narrow the list, Enter again deactivates (keeps filtered list), Escape clears.
+- **`g` keybinding simplified** — `gg` chord replaced with single `g` for jump-to-top in all contexts. `lastKey` chord state removed.
+- **Help menu overhaul** — two-column layout using full viewport width. Added Read Mode keybindings, Git Markers legend, updated all bindings to match current state.
+- **Documentation overhaul** — removed roadmap, future promises, and references to removed features. All docs now reflect current reality.
 
-### Features put on ice (backlogged)
+### Features on ice
 - **Full TODO system** — sweep, archive, categories, priorities. `internal/todo` package exists but is not wired to the TUI.
 - **Import/inbox pipeline** — `internal/importer` exists but `.inbox/` not scaffolded. CLI hidden.
-- **Git config** — removed from user-facing config. Git status detection still works.
-- **Delete feature** — `d` key disabled, `ModeDeleteConfirm` removed, `delete.go` removed.
-- **Search** — needs overhaul, flagged as next task.
+- **Delete feature** — `d` key disabled, delete confirmation flow removed.
 
-### Git status integration
-- `internal/git/git.go` — branch, ahead/behind, per-file status, stash count via `git` binary
-- Loaded async on: startup, editor return, manual `R` key
-- Status bar: branch name + `↑N`/`↓N` sync indicators
-- Per-file: styled markers in all tree views (Journal, KB, Tags, Dashboard)
-- No periodic polling, no `git fetch` — intentional
+### Five TUI panes
+1. Dashboard — journal / pinned / recent + todo.md preview
+2. Journal — month-folder tree
+3. KB — subtype-folder tree
+4. Tag Browser — tag list with substring filter + documents per tag
+5. Search — query input + results categorized by Journal/KB/Tags
 
-### Nerd font icons
-- All codepoints in `tui/icons.go` use `\U` escape sequences (e.g., `\U000F0415`)
-- Includes: document types, git status, pin, missing, cursor, dashboard, tag, filter
-
-### Directory structure
-- Scaffolded: `journal/`, `kb/`, `.templates/`
-- Singletons at base root: `todo.md`, `scratch.md`
+### Git integration
+- `internal/git/git.go` — branch, ahead/behind, per-file status via `git` binary
+- Loaded async on: startup, editor return, manual `R`
+- Per-file markers in all views (Journal, KB, Tags, Dashboard, Search)
 
 ### Config
 - Fields: editor, author, base_dir, export_dir, theme, nerd_fonts, journal.auto_create
-- No todo, git, or import sections
-
-## Next task: Search overhaul
-
-The search feature (`/`) needs a UX redesign. This was flagged by the user as the remaining sizable issue before the app is ready for regular use.
 
 ## All tests pass
 ```

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -7,7 +7,6 @@
 | Normal | Navigate, browse, trigger actions | Default | — |
 | Read | Full-screen glamour document viewer | `o` on a doc | `q` / `Esc` |
 | Command | Execute colon-prefixed commands | `:` | `Enter` / `Esc` |
-| Search | Fuzzy find across the document tree | `/` | `Enter` / `Esc` |
 
 ---
 
@@ -21,7 +20,7 @@
 | `k` / `↑` | Move up |
 | `h` / `←` | Switch to left panel; collapse tree folder if on a folder row |
 | `l` / `→` | Switch to right panel; expand tree folder if on a folder row |
-| `gg` | Jump to top |
+| `g` | Jump to top |
 | `G` | Jump to bottom |
 | `Tab` | Cycle to next pane |
 | `Shift+Tab` | Cycle to previous pane |
@@ -33,32 +32,29 @@
 | `1` | Dashboard |
 | `2` | Journal (month-folder tree) |
 | `3` | KB (subtype-folder tree) |
-| `4` | Tag Browser |
+| `4` | Tag Browser (with substring filter) |
+| `5` / `/` | Search |
 
 ### Document Actions
 
 | Key | Action |
 |---|---|
-| `Enter` | Open selected document in `$EDITOR` |
+| `Enter` | Open selected document in `$EDITOR`; on Tag Browser / Search left panel, activates filter input |
 | `o` | Open selected document in read mode |
 | `s` | Open scratch pad in `$EDITOR` |
 | `t` | Open todo in `$EDITOR` |
 | `n` | New document (template picker: journal or kb) |
 | `e` | Export selected document (strip frontmatter) |
 | `p` | Pin / unpin selected document |
-| `R` | Force re-scan directory tree |
-
-### Search
-
-| Key | Action |
-|---|---|
-| `/` | Enter search mode |
+| `R` | Force re-scan directory tree and git status |
+| `Esc` | Clear filter (Tag Browser) or search results (Search pane) |
 
 ### Application
 
 | Key | Action |
 |---|---|
 | `?` | Toggle keybinding help overlay |
+| `:` | Command mode |
 | `q` | Quit mdam |
 
 ---
@@ -91,17 +87,6 @@ Entered via `:`. Commands execute on `Enter`, cancel with `Esc`.
 
 ---
 
-## Search Mode
-
-| Key | Action |
-|---|---|
-| `Enter` | Confirm search, return to normal with results |
-| `Esc` | Cancel search |
-
-After searching, use `j`/`k` to navigate results and `Enter` to open.
-
----
-
 ## Journal Pane (key `2`)
 
 The left panel shows a month-folder tree. Only one month can be expanded at a time.
@@ -122,7 +107,7 @@ The current month is auto-expanded and the cursor lands on the most recent entry
 
 ## KB Pane (key `3`)
 
-The left panel shows a subtype-folder tree derived from the `type` field (e.g. `kb_summary` → "Summary" folder).
+The left panel shows a subtype-folder tree derived from the `type` field (e.g. `kb_summary` -> "Summary" folder).
 
 | Key | Action |
 |---|---|
@@ -138,14 +123,37 @@ The left panel shows a subtype-folder tree derived from the `type` field (e.g. `
 
 ## Tag Browser (key `4`)
 
-The left panel lists all tags sorted by document count. The right panel shows documents carrying the selected tag.
+The left panel lists all tags sorted alphabetically. The right panel shows documents carrying the selected tag.
 
 | Key | Panel | Action |
 |---|---|---|
+| `Enter` | Left | Activate the filter input — type to narrow the tag list by substring |
+| `Enter` | Left (filter active) | Deactivate filter input, keep filtered list, navigate with `j`/`k` |
+| `Esc` | Left | Clear the filter, restore full tag list |
 | `j` / `k` | Left | Navigate tags |
 | `l` / `h` | — | Switch between tag list and document list |
 | `j` / `k` | Right | Navigate documents for selected tag |
 | `Enter` | Right | Open highlighted document in `$EDITOR` |
+| `o` | Right | Open highlighted document in read mode |
+
+---
+
+## Search Pane (key `5` or `/`)
+
+Two-column layout. Left panel has a search input and three category entries (Journal, KB, Tags). Right panel shows documents for the selected category.
+
+| Key | Panel | Action |
+|---|---|---|
+| `Enter` | Left | Activate the search input — type a query, press Enter to search |
+| `Enter` | Left (input active) | Execute search, deactivate input |
+| `Esc` | Left (input active) | Deactivate input without searching |
+| `Esc` | — | Clear search results and reset to empty state |
+| `j` / `k` | Left | Navigate categories (Journal, KB, Tags) |
+| `l` / `h` | — | Switch between category list and document list |
+| `j` / `k` | Right | Navigate documents in selected category |
+| `Enter` | Right | Open highlighted document in `$EDITOR` |
+| `o` | Right | Open highlighted document in read mode |
+| `p` | Right | Pin / unpin highlighted document |
 
 ---
 

--- a/docs/TODO-FORMAT.md
+++ b/docs/TODO-FORMAT.md
@@ -16,11 +16,3 @@ Use standard markdown checkboxes:
 - Press `Enter` on `todo.md` in any file list to open it.
 - The Dashboard (key `1`) shows a glamour-rendered preview of `todo.md` in the right panel.
 
-## Planned features
-
-The following TODO features are planned for a future release:
-
-- **Categories** — `@work`, `@personal` grouping labels
-- **Priorities** — `!high`, `!medium`, `!low` flags
-- **Sweep** — auto-carry incomplete tasks from journal entries
-- **Archive** — move old completed tasks to a separate file

--- a/docs/TUI-UX.md
+++ b/docs/TUI-UX.md
@@ -163,6 +163,9 @@ Every view that renders a list, tree, or panel must handle the empty case explic
 | Dashboard — TODOs | No open tasks | `No open tasks.` |
 | Preview panel | No document selected | `Select a document to preview.` |
 | Search results | Query returns nothing | `No results for "{query}".` |
+| Search pane (left) | No search executed | `Type a query and press Enter.` |
+| Search pane (right) | Category has no docs | `No documents in this category.` |
+| Tag browser filter | Filter has no matches | `No matching tags.` |
 
 ### 5.2 Placeholder style
 Placeholder text uses the **Muted** style and is rendered at the top of the content

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -167,7 +167,7 @@ func scoreDocument(doc document.Document, query string, includeBody bool) (int, 
 	for _, tag := range doc.Frontmatter.Tags {
 		if strings.EqualFold(tag, query) {
 			score += 100
-		} else if fuzzyContains(strings.ToLower(tag), q) {
+		} else if FuzzyContains(strings.ToLower(tag), q) {
 			score += 40
 		}
 	}
@@ -176,7 +176,7 @@ func scoreDocument(doc document.Document, query string, includeBody bool) (int, 
 	title := strings.ToLower(doc.Frontmatter.Title)
 	if strings.Contains(title, q) {
 		score += 50
-	} else if fuzzyContains(title, q) {
+	} else if FuzzyContains(title, q) {
 		score += 25
 	}
 
@@ -184,7 +184,7 @@ func scoreDocument(doc document.Document, query string, includeBody bool) (int, 
 	filename := strings.ToLower(filepath.Base(doc.Path))
 	if strings.Contains(filename, q) {
 		score += 30
-	} else if fuzzyContains(filename, q) {
+	} else if FuzzyContains(filename, q) {
 		score += 15
 	}
 
@@ -194,7 +194,7 @@ func scoreDocument(doc document.Document, query string, includeBody bool) (int, 
 		if idx := strings.Index(body, q); idx != -1 {
 			score += 10
 			snippet = extractSnippet(doc.Body, idx, 80)
-		} else if fuzzyContains(body, q) {
+		} else if FuzzyContains(body, q) {
 			score += 5
 		}
 	}
@@ -202,8 +202,8 @@ func scoreDocument(doc document.Document, query string, includeBody bool) (int, 
 	return score, snippet
 }
 
-// fuzzyContains reports whether all runes of sub appear in s in order.
-func fuzzyContains(s, sub string) bool {
+// FuzzyContains reports whether all runes of sub appear in s in order.
+func FuzzyContains(s, sub string) bool {
 	if sub == "" {
 		return true
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -145,9 +145,9 @@ func TestFuzzyContains(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.s+"/"+tt.sub, func(t *testing.T) {
-			got := fuzzyContains(tt.s, tt.sub)
+			got := FuzzyContains(tt.s, tt.sub)
 			if got != tt.want {
-				t.Errorf("fuzzyContains(%q, %q) = %v, want %v", tt.s, tt.sub, got, tt.want)
+				t.Errorf("FuzzyContains(%q, %q) = %v, want %v", tt.s, tt.sub, got, tt.want)
 			}
 		})
 	}

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -26,6 +26,7 @@ type KeyMap struct {
 	ViewJournal   key.Binding // 2
 	ViewKB        key.Binding // 3
 	ViewTags      key.Binding // 4
+	ViewSearchKey key.Binding // 5
 
 	// Actions
 	Quit          key.Binding // q
@@ -61,6 +62,7 @@ func DefaultKeyMap() KeyMap {
 		ViewJournal:   key.NewBinding(key.WithKeys("2"), key.WithHelp("2", "journal")),
 		ViewKB:        key.NewBinding(key.WithKeys("3"), key.WithHelp("3", "kb")),
 		ViewTags:      key.NewBinding(key.WithKeys("4"), key.WithHelp("4", "tag browser")),
+		ViewSearchKey: key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "search")),
 
 		Quit:          key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
 		Rescan:        key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "rescan")),

--- a/tui/mode.go
+++ b/tui/mode.go
@@ -9,8 +9,6 @@ const (
 	ModeNormal Mode = iota
 	// ModeCommand is activated by ":" — accepts colon-prefixed commands.
 	ModeCommand
-	// ModeSearch is activated by "/" — accepts fuzzy search queries.
-	ModeSearch
 	// ModeTemplatePicker is the template selection overlay for new documents.
 	ModeTemplatePicker
 	// ModeTemplateVars collects values for unresolved template variables.
@@ -25,8 +23,6 @@ func (m Mode) String() string {
 		return "NORMAL"
 	case ModeCommand:
 		return "COMMAND"
-	case ModeSearch:
-		return "SEARCH"
 	case ModeTemplatePicker, ModeTemplateVars:
 		return "NEW DOC"
 	case ModeRead:
@@ -44,11 +40,12 @@ const (
 	ViewJournal               // key 2
 	ViewKB                    // key 3
 	ViewTags                  // key 4
+	ViewSearch                // key 5
 )
 
 // cycleView advances the active view by delta (1 or -1), wrapping around.
 func cycleView(v View, delta int) View {
-	const n = 4 // total number of named views
+	const n = 5 // total number of named views
 	return View((int(v) + delta + n) % n)
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -53,9 +53,15 @@ type Model struct {
 	gitStatus  git.RepoStatus
 	gitFileMap map[string]git.FileStatus // path → status for O(1) lookup
 
-	// --- Search state ---
-	searchResults []search.Result
-	searchActive  bool // true = showing search results in file panel
+	// --- Search pane (View 5) ---
+	searchPaneInput    textinput.Model
+	searchPaneQuery    string           // last executed query
+	searchJournalDocs  []search.Result  // results where type == "journal"
+	searchKBDocs       []search.Result  // results where type starts with "kb"
+	searchTagDocs      []search.Result  // results that matched via tag
+	searchCatCursor    int              // 0=Journal, 1=KB, 2=Tags
+	searchDocCursor    int              // right panel cursor
+	searchInputFocused bool
 
 	// --- Template picker state ---
 	templates      []tmpl.Template
@@ -97,9 +103,12 @@ type Model struct {
 	dashRight  bool // true = focus on right (TODO) column
 
 	// --- Tag browser ---
-	tagEntries   []tagEntry
-	tagCursor    int
-	tagDocCursor int // cursor within the documents panel on the right
+	tagEntries         []tagEntry
+	tagCursor          int
+	tagDocCursor       int // cursor within the documents panel on the right
+	tagFilterInput     textinput.Model
+	tagFilterActive    bool
+	tagFilteredEntries []tagEntry
 
 	// --- Spinner ---
 	spinnerFrame int
@@ -108,12 +117,8 @@ type Model struct {
 	loading  bool
 	errorMsg string
 
-	// --- Chord state ---
-	lastKey string
-
 	// --- Mode inputs ---
-	cmdInput    textinput.Model
-	searchInput textinput.Model
+	cmdInput textinput.Model
 
 	// --- Help overlay ---
 	showHelp bool
@@ -132,9 +137,13 @@ func New(cfg config.Config) Model {
 	cmd.Placeholder = "command"
 	cmd.CharLimit = 256
 
-	srch := textinput.New()
-	srch.Placeholder = "search"
-	srch.CharLimit = 256
+	searchIn := textinput.New()
+	searchIn.Placeholder = "search..."
+	searchIn.CharLimit = 256
+
+	tagFilter := textinput.New()
+	tagFilter.Placeholder = "filter tags..."
+	tagFilter.CharLimit = 256
 
 	varIn := textinput.New()
 	varIn.CharLimit = 256
@@ -160,7 +169,8 @@ func New(cfg config.Config) Model {
 		kbExpanded:      make(map[string]bool),
 		loading:         true,
 		cmdInput:        cmd,
-		searchInput:     srch,
+		searchPaneInput: searchIn,
+		tagFilterInput:  tagFilter,
 		varInput:        varIn,
 		width:           80,
 		height:          24,
@@ -260,17 +270,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case searchDoneMsg:
 		if msg.err == nil {
-			m.searchResults = msg.results
-			m.searchActive = true
-			if len(msg.results) == 0 {
+			m.searchPaneQuery = msg.query
+			m.searchJournalDocs, m.searchKBDocs, m.searchTagDocs = categorizeResults(msg.results, msg.query)
+			m.searchCatCursor = 0
+			m.searchDocCursor = 0
+			m.searchInputFocused = false
+			total := len(msg.results)
+			if total == 0 {
 				m.statusMsg = fmt.Sprintf("no results for %q", msg.query)
 			} else {
-				m.statusMsg = fmt.Sprintf("%d results for %q", len(msg.results), msg.query)
+				m.statusMsg = fmt.Sprintf("%d results for %q", total, msg.query)
 			}
 		} else {
 			m.errorMsg = fmt.Sprintf("search error: %v", msg.err)
 		}
-		m.fileCursor = 0
 		return m, nil
 
 	case exportDoneMsg:
@@ -347,8 +360,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateNormal(msg)
 		case ModeCommand:
 			return m.updateCommand(msg)
-		case ModeSearch:
-			return m.updateSearch(msg)
 		case ModeTemplatePicker:
 			return m.updateTemplatePicker(msg)
 		case ModeTemplateVars:
@@ -364,16 +375,65 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	k := msg.String()
 
-	// Handle gg chord: two consecutive 'g' presses → jump to top.
-	if k == "g" {
-		if m.lastKey == "g" {
-			m.lastKey = ""
-			return m.jumpTop(), nil
+	// Text input routing must come before the gg chord handler so that
+	// characters like "g" reach the input instead of being captured.
+
+	// Search pane: when input is focused, route keys to the text input.
+	if m.searchInputFocused && m.activeView == ViewSearch {
+		switch k {
+		case "esc":
+			m.searchInputFocused = false
+			m.searchPaneInput.Blur()
+			return m, nil
+		case "enter":
+			query := strings.TrimSpace(m.searchPaneInput.Value())
+			m.searchInputFocused = false
+			m.searchPaneInput.Blur()
+			if query == "" {
+				return m, nil
+			}
+			return m, cmdSearch(m.cfg.BaseDir, query, search.Filters{})
+		case "ctrl+c":
+			return m, tea.Quit
 		}
-		m.lastKey = "g"
-		return m, nil
+		var teaCmd tea.Cmd
+		m.searchPaneInput, teaCmd = m.searchPaneInput.Update(msg)
+		return m, teaCmd
 	}
-	m.lastKey = k
+
+	// Tag browser: when filter is active, route keys to the filter input.
+	if m.tagFilterActive && m.activeView == ViewTags {
+		switch k {
+		case "esc":
+			m.tagFilterActive = false
+			m.tagFilterInput.Blur()
+			m.tagFilterInput.SetValue("")
+			m.tagFilteredEntries = nil
+			return m, nil
+		case "enter":
+			m.tagFilterActive = false
+			m.tagFilterInput.Blur()
+			return m, nil
+		case "ctrl+c":
+			return m, tea.Quit
+		}
+		var teaCmd tea.Cmd
+		m.tagFilterInput, teaCmd = m.tagFilterInput.Update(msg)
+		// Recompute filtered entries on each keystroke.
+		m.tagFilteredEntries = filterTagEntries(m.tagEntries, m.tagFilterInput.Value())
+		if m.tagCursor >= len(m.tagFilteredEntries) && len(m.tagFilteredEntries) > 0 {
+			m.tagCursor = len(m.tagFilteredEntries) - 1
+		} else if len(m.tagFilteredEntries) == 0 {
+			m.tagCursor = 0
+		}
+		m.tagDocCursor = 0
+		return m, teaCmd
+	}
+
+	// Single 'g' jumps to top (matching read mode).
+	if k == "g" {
+		return m.jumpTop(), nil
+	}
 
 	switch {
 	// Quit
@@ -462,9 +522,27 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// Tag Browser: l/h move focus between panels without wrapping.
 	case (k == "l" || k == "right") && m.activeView == ViewTags:
-		m.activePanel = PanelPreview
+		if m.tagFilterActive {
+			// Don't switch panels while filter input is active.
+		} else {
+			m.activePanel = PanelPreview
+		}
 	case (k == "h" || k == "left") && m.activeView == ViewTags:
-		m.activePanel = PanelFiles
+		if m.tagFilterActive {
+			// Don't switch panels while filter input is active.
+		} else {
+			m.activePanel = PanelFiles
+		}
+
+	// Search pane: l/h move focus between panels without wrapping.
+	case (k == "l" || k == "right") && m.activeView == ViewSearch:
+		if !m.searchInputFocused {
+			m.activePanel = PanelPreview
+		}
+	case (k == "h" || k == "left") && m.activeView == ViewSearch:
+		if !m.searchInputFocused {
+			m.activePanel = PanelFiles
+		}
 
 	// Panel navigation (h/l move focus between panels)
 	case k == "l", k == "right":
@@ -472,18 +550,35 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case k == "h", k == "left":
 		m.activePanel = m.activePanel.prev()
 
-	// Mode transitions
+	// Search pane (/ opens search pane)
 	case k == "/":
-		m.mode = ModeSearch
-		m.searchInput.SetValue("")
+		m.activeView = ViewSearch
+		m.activePanel = PanelFiles
 		m.statusMsg = ""
-		return m, m.searchInput.Focus()
 
 	case k == ":":
 		m.mode = ModeCommand
 		m.cmdInput.SetValue("")
 		m.statusMsg = ""
 		return m, m.cmdInput.Focus()
+
+	// Escape on Search pane: clear results and reset to empty state.
+	case k == "esc" && m.activeView == ViewSearch:
+		m.searchPaneQuery = ""
+		m.searchJournalDocs = nil
+		m.searchKBDocs = nil
+		m.searchTagDocs = nil
+		m.searchCatCursor = 0
+		m.searchDocCursor = 0
+		m.searchPaneInput.SetValue("")
+		m.statusMsg = ""
+
+	// Escape on Tag Browser: clear the filter if one is set.
+	case k == "esc" && m.activeView == ViewTags:
+		m.tagFilterInput.SetValue("")
+		m.tagFilteredEntries = nil
+		m.tagCursor = 0
+		m.tagDocCursor = 0
 
 	// Help overlay
 	case k == "?":
@@ -492,32 +587,34 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Number keys — pane switching
 	case k == "1":
 		m.activeView = ViewDashboard
-		m.searchActive = false
 		m.dashCursor = 0
 		m.dashRight = false
 		m.activePanel = PanelFiles
 		m.statusMsg = ""
 	case k == "2":
 		m.activeView = ViewJournal
-		m.searchActive = false
 		m.activePanel = PanelFiles
 		m.statusMsg = ""
 		m.preview.SetContent("") // clear stale content from previous view
 		m = initJournalView(m)
 	case k == "3":
 		m.activeView = ViewKB
-		m.searchActive = false
 		m.kbCursor = 0
 		m.activePanel = PanelFiles
 		m.statusMsg = ""
 		m.preview.SetContent("") // clear stale content from previous view
 	case k == "4":
 		m.activeView = ViewTags
-		m.searchActive = false
 		m.tagCursor = 0
+		m.tagFilterActive = false
+		m.tagFilterInput.SetValue("")
 		m.activePanel = PanelFiles // always reset to left panel on entry (§9 Bug 1)
 		m.statusMsg = ""
 		return m, cmdBuildTagIndex(m.docs)
+	case k == "5":
+		m.activeView = ViewSearch
+		m.activePanel = PanelFiles
+		m.statusMsg = ""
 
 	// Open in $EDITOR
 	case k == "enter":
@@ -594,6 +691,13 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Tag browser: Enter on left panel activates the filter input.
+		if m.activeView == ViewTags && m.activePanel == PanelFiles {
+			m.tagFilterActive = true
+			m.tagFilterInput.SetValue("")
+			m.tagFilteredEntries = nil
+			return m, m.tagFilterInput.Focus()
+		}
 		// Tag browser: Enter on doc panel opens the highlighted tagged doc.
 		if m.activeView == ViewTags && m.activePanel == PanelPreview {
 			tagged := m.taggedDocs()
@@ -604,6 +708,25 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					return m, nil
 				}
 				return m, cmdOpenEditor(tagged[m.tagDocCursor].Path, editor)
+			}
+			m.statusMsg = "no document selected"
+			return m, nil
+		}
+		// Search pane: Enter on left panel focuses the input.
+		if m.activeView == ViewSearch && m.activePanel == PanelFiles {
+			m.searchInputFocused = true
+			return m, m.searchPaneInput.Focus()
+		}
+		// Search pane: Enter on right panel opens the highlighted doc in editor.
+		if m.activeView == ViewSearch && m.activePanel == PanelPreview {
+			docs := m.searchCategoryDocs()
+			if m.searchDocCursor < len(docs) {
+				editor := resolveEditor(m.cfg.Editor)
+				if editor == "" {
+					m.statusMsg = "no editor configured ($EDITOR not set)"
+					return m, nil
+				}
+				return m, cmdOpenEditor(docs[m.searchDocCursor].Path, editor)
 			}
 			m.statusMsg = "no document selected"
 			return m, nil
@@ -625,6 +748,25 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			tagged := m.taggedDocs()
 			if m.tagDocCursor < len(tagged) {
 				d := tagged[m.tagDocCursor]
+				title := d.Frontmatter.Title
+				if title == "" {
+					title = filepath.Base(d.Path)
+				}
+				m.readReturnView = m.activeView
+				m.readReturnPanel = m.activePanel
+				m.readDocTitle = title
+				m.readViewport = viewport.New(m.width, m.height-3)
+				m.mode = ModeRead
+				return m, cmdLoadRead(d.Path, m.theme.GlamourStyle, m.width)
+			}
+			m.statusMsg = "no document selected"
+			return m, nil
+		}
+		// Search pane: o on right panel opens the highlighted doc in read mode.
+		if m.activeView == ViewSearch && m.activePanel == PanelPreview {
+			docs := m.searchCategoryDocs()
+			if m.searchDocCursor < len(docs) {
+				d := docs[m.searchDocCursor]
 				title := d.Frontmatter.Title
 				if title == "" {
 					title = filepath.Base(d.Path)
@@ -797,35 +939,6 @@ func (m Model) updateCommand(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, teaCmd
 }
 
-// updateSearch handles key events in Search mode.
-func (m Model) updateSearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "esc":
-		m.mode = ModeNormal
-		m.searchInput.Blur()
-		m.searchActive = false
-		m.statusMsg = ""
-		return m, nil
-
-	case "enter":
-		query := strings.TrimSpace(m.searchInput.Value())
-		m.mode = ModeNormal
-		m.searchInput.Blur()
-		if query == "" {
-			m.searchActive = false
-			m.statusMsg = ""
-			return m, nil
-		}
-		return m, cmdSearch(m.cfg.BaseDir, query, search.Filters{})
-
-	case "ctrl+c":
-		return m, tea.Quit
-	}
-
-	var teaCmd tea.Cmd
-	m.searchInput, teaCmd = m.searchInput.Update(msg)
-	return m, teaCmd
-}
 
 // updateTemplatePicker handles key events in the template picker mode.
 func (m Model) updateTemplatePicker(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -965,6 +1078,13 @@ func (m Model) selectedDoc() string {
 	if m.activeView == ViewKB {
 		return m.kbSelectedPath()
 	}
+	if m.activeView == ViewSearch {
+		docs := m.searchCategoryDocs()
+		if m.searchDocCursor >= 0 && m.searchDocCursor < len(docs) {
+			return docs[m.searchDocCursor].Path
+		}
+		return ""
+	}
 	docs := m.visibleDocs()
 	if m.fileCursor >= 0 && m.fileCursor < len(docs) {
 		return docs[m.fileCursor].Path
@@ -1027,9 +1147,6 @@ func (m Model) selectedDocTitle() string {
 
 // visibleDocs returns the slice of documents appropriate for the current view.
 func (m Model) visibleDocs() []search.Result {
-	if m.searchActive {
-		return m.searchResults
-	}
 	switch m.activeView {
 	case ViewJournal:
 		return filterByType(m.docs, "journal")
@@ -1037,6 +1154,8 @@ func (m Model) visibleDocs() []search.Result {
 		return filterKBDocs(m.docs)
 	case ViewTags:
 		return nil // tag browser uses tagEntries, not docs
+	case ViewSearch:
+		return nil // search pane uses its own categorized lists
 	default:
 		return m.docs
 	}
@@ -1078,6 +1197,11 @@ func highlightedRelPath(m Model) string {
 		if m.tagDocCursor >= 0 && m.tagDocCursor < len(tagged) {
 			absPath = tagged[m.tagDocCursor].Path
 		}
+	case m.activeView == ViewSearch && m.activePanel == PanelPreview:
+		docs := m.searchCategoryDocs()
+		if m.searchDocCursor >= 0 && m.searchDocCursor < len(docs) {
+			absPath = docs[m.searchDocCursor].Path
+		}
 	default:
 		docs := m.visibleDocs()
 		if m.fileCursor >= 0 && m.fileCursor < len(docs) {
@@ -1096,10 +1220,11 @@ func highlightedRelPath(m Model) string {
 
 // taggedDocs returns the documents that carry the currently selected tag.
 func (m Model) taggedDocs() []search.Result {
-	if m.tagCursor >= len(m.tagEntries) {
+	entries := m.visibleTagEntries()
+	if m.tagCursor >= len(entries) {
 		return nil
 	}
-	tag := m.tagEntries[m.tagCursor].Name
+	tag := entries[m.tagCursor].Name
 	var out []search.Result
 	for _, d := range m.docs {
 		for _, t := range d.Frontmatter.Tags {
@@ -1110,6 +1235,67 @@ func (m Model) taggedDocs() []search.Result {
 		}
 	}
 	return out
+}
+
+// searchCategoryDocs returns the doc list for the currently selected search category.
+func (m Model) searchCategoryDocs() []search.Result {
+	switch m.searchCatCursor {
+	case 0:
+		return m.searchJournalDocs
+	case 1:
+		return m.searchKBDocs
+	case 2:
+		return m.searchTagDocs
+	default:
+		return nil
+	}
+}
+
+// categorizeResults splits search results into journal, KB, and tag-matched buckets.
+// A document can appear in multiple categories.
+func categorizeResults(results []search.Result, query string) (journal, kb, tags []search.Result) {
+	q := strings.ToLower(query)
+	for _, r := range results {
+		t := strings.ToLower(r.Frontmatter.Type)
+		if t == "journal" {
+			journal = append(journal, r)
+		}
+		if strings.HasPrefix(t, "kb") {
+			kb = append(kb, r)
+		}
+		for _, tag := range r.Frontmatter.Tags {
+			if search.FuzzyContains(strings.ToLower(tag), q) {
+				tags = append(tags, r)
+				break
+			}
+		}
+	}
+	return
+}
+
+// filterTagEntries returns tag entries whose names contain the filter as a substring.
+func filterTagEntries(entries []tagEntry, filter string) []tagEntry {
+	if filter == "" {
+		return entries
+	}
+	q := strings.ToLower(filter)
+	var out []tagEntry
+	for _, e := range entries {
+		if strings.Contains(strings.ToLower(e.Name), q) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// visibleTagEntries returns the tag entries visible in the tag browser,
+// respecting the active filter. The filtered list persists after the input
+// is deactivated so the user can navigate the narrowed results.
+func (m Model) visibleTagEntries() []tagEntry {
+	if m.tagFilterInput.Value() != "" {
+		return m.tagFilteredEntries
+	}
+	return m.tagEntries
 }
 
 // filterByType returns results matching the given document type.
@@ -1163,16 +1349,28 @@ func (m Model) moveCursorDown() Model {
 			m.kbCursor++
 		}
 	case m.activeView == ViewTags && m.activePanel == PanelFiles:
-		if m.tagCursor < len(m.tagEntries)-1 {
+		entries := m.visibleTagEntries()
+		if m.tagCursor < len(entries)-1 {
 			m.tagCursor++
 			m.tagDocCursor = 0 // reset doc cursor when tag changes
 		}
 	case m.activeView == ViewTags && m.activePanel == PanelPreview:
-		if m.tagCursor < len(m.tagEntries) {
+		entries := m.visibleTagEntries()
+		if m.tagCursor < len(entries) {
 			tagged := m.taggedDocs()
 			if m.tagDocCursor < len(tagged)-1 {
 				m.tagDocCursor++
 			}
+		}
+	case m.activeView == ViewSearch && m.activePanel == PanelFiles:
+		if m.searchCatCursor < 2 {
+			m.searchCatCursor++
+			m.searchDocCursor = 0
+		}
+	case m.activeView == ViewSearch && m.activePanel == PanelPreview:
+		docs := m.searchCategoryDocs()
+		if m.searchDocCursor < len(docs)-1 {
+			m.searchDocCursor++
 		}
 	case m.activePanel == PanelFiles:
 		docs := m.visibleDocs()
@@ -1213,6 +1411,15 @@ func (m Model) moveCursorUp() Model {
 		if m.tagDocCursor > 0 {
 			m.tagDocCursor--
 		}
+	case m.activeView == ViewSearch && m.activePanel == PanelFiles:
+		if m.searchCatCursor > 0 {
+			m.searchCatCursor--
+			m.searchDocCursor = 0
+		}
+	case m.activeView == ViewSearch && m.activePanel == PanelPreview:
+		if m.searchDocCursor > 0 {
+			m.searchDocCursor--
+		}
 	case m.activePanel == PanelFiles:
 		if m.fileCursor > 0 {
 			m.fileCursor--
@@ -1239,6 +1446,9 @@ func (m Model) jumpTop() Model {
 			m.kbCursor = 0
 		case ViewTags:
 			m.tagCursor = 0
+		case ViewSearch:
+			m.searchCatCursor = 0
+			m.searchDocCursor = 0
 		default:
 			m.fileCursor = 0
 		}
@@ -1260,9 +1470,13 @@ func (m Model) jumpBottom() Model {
 				m.kbCursor = len(rows) - 1
 			}
 		case ViewTags:
-			if len(m.tagEntries) > 0 {
-				m.tagCursor = len(m.tagEntries) - 1
+			entries := m.visibleTagEntries()
+			if len(entries) > 0 {
+				m.tagCursor = len(entries) - 1
 			}
+		case ViewSearch:
+			m.searchCatCursor = 2
+			m.searchDocCursor = 0
 		default:
 			docs := m.visibleDocs()
 			if len(docs) > 0 {

--- a/tui/model_test.go
+++ b/tui/model_test.go
@@ -135,7 +135,6 @@ func TestModeString(t *testing.T) {
 	}{
 		{ModeNormal, "NORMAL"},
 		{ModeCommand, "COMMAND"},
-		{ModeSearch, "SEARCH"},
 		{ModeTemplatePicker, "NEW DOC"},
 		{ModeTemplateVars, "NEW DOC"},
 	}
@@ -254,24 +253,39 @@ func TestTabCyclesPanes(t *testing.T) {
 		t.Errorf("after third tab: view = %v, want ViewTags", m.activeView)
 	}
 	m = sendKey(m, "tab")
+	if m.activeView != ViewSearch {
+		t.Errorf("after fourth tab: view = %v, want ViewSearch", m.activeView)
+	}
+	m = sendKey(m, "tab")
 	if m.activeView != ViewDashboard {
-		t.Errorf("after fourth tab: view = %v, want ViewDashboard (wrap)", m.activeView)
+		t.Errorf("after fifth tab: view = %v, want ViewDashboard (wrap)", m.activeView)
 	}
 }
 
 func TestShiftTabCyclesPanesReverse(t *testing.T) {
 	m := newTestModel()
 	m = sendKey(m, "shift+tab")
-	if m.activeView != ViewTags {
-		t.Errorf("shift+tab from ViewDashboard = %v, want ViewTags", m.activeView)
+	if m.activeView != ViewSearch {
+		t.Errorf("shift+tab from ViewDashboard = %v, want ViewSearch", m.activeView)
 	}
 }
 
-func TestEnterSearchMode(t *testing.T) {
+func TestSlashSwitchesToSearchView(t *testing.T) {
 	m := newTestModel()
 	m = sendKey(m, "/")
-	if m.mode != ModeSearch {
-		t.Errorf("mode = %v, want ModeSearch", m.mode)
+	if m.activeView != ViewSearch {
+		t.Errorf("activeView = %v, want ViewSearch", m.activeView)
+	}
+	if m.searchInputFocused {
+		t.Error("searchInputFocused should be false — Enter activates it")
+	}
+}
+
+func TestKey5SwitchesToSearchView(t *testing.T) {
+	m := newTestModel()
+	m = sendKey(m, "5")
+	if m.activeView != ViewSearch {
+		t.Errorf("activeView = %v, want ViewSearch", m.activeView)
 	}
 }
 
@@ -380,14 +394,14 @@ func TestViewHelpOverlay(t *testing.T) {
 	}
 }
 
-func TestViewInSearchMode(t *testing.T) {
+func TestViewInSearchPane(t *testing.T) {
 	m := newTestModel()
 	m.width = 80
 	m.height = 24
 	m = sendKey(m, "/")
 	view := stripANSI(m.View())
-	if !strings.Contains(view, "SEARCH") {
-		t.Errorf("view in search mode missing SEARCH indicator")
+	if !strings.Contains(view, "5: Search") {
+		t.Errorf("view in search pane missing '5: Search' tab, got:\n%s", view)
 	}
 }
 
@@ -402,12 +416,12 @@ func TestViewInCommandMode(t *testing.T) {
 	}
 }
 
-func TestSearchEnterReturnsToNormal(t *testing.T) {
+func TestSearchEnterActivatesInput(t *testing.T) {
 	m := newTestModel()
-	m = sendKey(m, "/")
-	m = sendKey(m, "enter")
-	if m.mode != ModeNormal {
-		t.Errorf("after search Enter: mode = %v, want ModeNormal", m.mode)
+	m = sendKey(m, "/")     // switches to search pane, input not focused
+	m = sendKey(m, "enter") // activates input
+	if !m.searchInputFocused {
+		t.Error("searchInputFocused should be true after Enter on left panel")
 	}
 }
 
@@ -562,13 +576,18 @@ func TestGitStatusLoaded(t *testing.T) {
 
 func TestSearchResults(t *testing.T) {
 	m := newTestModel()
-	results := fakeDocs[:1]
-	m = sendMsg(m, searchDoneMsg{results: results, query: "nginx"})
-	if !m.searchActive {
-		t.Error("searchActive should be true after searchDoneMsg")
+	results := fakeDocs // journal + journal + kb
+	m = sendMsg(m, searchDoneMsg{results: results, query: "daily"})
+	if m.searchPaneQuery != "daily" {
+		t.Errorf("searchPaneQuery = %q, want %q", m.searchPaneQuery, "daily")
 	}
-	if len(m.searchResults) != 1 {
-		t.Errorf("searchResults count = %d, want 1", len(m.searchResults))
+	// "daily" is a tag on the two journal docs, so searchTagDocs should have 2.
+	if len(m.searchTagDocs) != 2 {
+		t.Errorf("searchTagDocs count = %d, want 2", len(m.searchTagDocs))
+	}
+	// Two journal docs in results.
+	if len(m.searchJournalDocs) != 2 {
+		t.Errorf("searchJournalDocs count = %d, want 2", len(m.searchJournalDocs))
 	}
 }
 
@@ -618,13 +637,12 @@ func TestRecentDocsHelper(t *testing.T) {
 	}
 }
 
-func TestVisibleDocsSearch(t *testing.T) {
+func TestVisibleDocsSearchReturnsNil(t *testing.T) {
 	m := modelWithDocs()
-	m.searchResults = fakeDocs[:1]
-	m.searchActive = true
+	m.activeView = ViewSearch
 	docs := m.visibleDocs()
-	if len(docs) != 1 {
-		t.Errorf("searchActive: visible docs = %d, want 1", len(docs))
+	if docs != nil {
+		t.Errorf("ViewSearch: visibleDocs should return nil, got %v", docs)
 	}
 }
 
@@ -785,12 +803,10 @@ func TestViewSwitching(t *testing.T) {
 
 func TestOldViewKeysNoop(t *testing.T) {
 	m := newTestModel()
-	// Keys 5 and 6 no longer switch views.
-	for _, k := range []string{"5", "6"} {
-		m2 := sendKey(m, k)
-		if m2.activeView != ViewDashboard {
-			t.Errorf("key %q should not change view, got %v", k, m2.activeView)
-		}
+	// Key 6 does not switch views.
+	m2 := sendKey(m, "6")
+	if m2.activeView != ViewDashboard {
+		t.Errorf("key %q should not change view, got %v", "6", m2.activeView)
 	}
 }
 
@@ -1003,9 +1019,10 @@ func TestCycleView(t *testing.T) {
 		want  View
 	}{
 		{ViewDashboard, 1, ViewJournal},
-		{ViewTags, 1, ViewDashboard}, // wraps
-		{ViewDashboard, -1, ViewTags}, // wraps backward
+		{ViewSearch, 1, ViewDashboard},     // wraps
+		{ViewDashboard, -1, ViewSearch},     // wraps backward
 		{ViewJournal, -1, ViewDashboard},
+		{ViewTags, 1, ViewSearch},
 	}
 	for _, tt := range tests {
 		got := cycleView(tt.start, tt.delta)

--- a/tui/view.go
+++ b/tui/view.go
@@ -33,6 +33,7 @@ func (m Model) renderTabBar() string {
 		{ViewJournal, "2: Journal"},
 		{ViewKB, "3: KB"},
 		{ViewTags, "4: Tag Browser"},
+		{ViewSearch, "5: Search"},
 	}
 
 	var parts []string
@@ -88,6 +89,9 @@ func (m Model) View() string {
 	}
 	if m.activeView == ViewTags {
 		return m.renderTagBrowser()
+	}
+	if m.activeView == ViewSearch {
+		return m.renderSearchPane()
 	}
 
 	var b strings.Builder
@@ -308,8 +312,6 @@ func (m Model) renderStatusBar() string {
 	switch m.mode {
 	case ModeCommand:
 		modeStyle = m.theme.StatusCommand
-	case ModeSearch:
-		modeStyle = m.theme.StatusSearch
 	case ModeTemplatePicker, ModeTemplateVars:
 		modeStyle = m.theme.StatusNewDoc
 	default:
@@ -359,8 +361,6 @@ func (m Model) renderStatusBar() string {
 	switch m.mode {
 	case ModeCommand:
 		right = m.theme.StatusMsg.Render(":") + m.cmdInput.View()
-	case ModeSearch:
-		right = m.theme.StatusMsg.Render("/") + m.searchInput.View()
 	default:
 		if m.statusMsg != "" {
 			right = m.theme.StatusMsg.Render(m.statusMsg)
@@ -432,41 +432,62 @@ func (m Model) viewHelp() string {
 	k := m.theme.Subtle
 	n := m.theme.FileNormal
 
+	// Left column: Navigation, Panes, Actions.
+	var left strings.Builder
+	left.WriteString(h.Render("Navigation") + "\n")
+	left.WriteString(k.Render("  j / k       ") + n.Render("move down / up") + "\n")
+	left.WriteString(k.Render("  h / l       ") + n.Render("prev / next panel") + "\n")
+	left.WriteString(k.Render("  g / G       ") + n.Render("top / bottom") + "\n")
+	left.WriteString(k.Render("  Tab         ") + n.Render("next pane") + "\n")
+	left.WriteString(k.Render("  Shift+Tab   ") + n.Render("prev pane") + "\n\n")
+
+	left.WriteString(h.Render("Panes") + "\n")
+	left.WriteString(k.Render("  1           ") + n.Render("dashboard") + "\n")
+	left.WriteString(k.Render("  2           ") + n.Render("journal") + "\n")
+	left.WriteString(k.Render("  3           ") + n.Render("knowledge base") + "\n")
+	left.WriteString(k.Render("  4           ") + n.Render("tag browser") + "\n")
+	left.WriteString(k.Render("  5 / /       ") + n.Render("search") + "\n\n")
+
+	left.WriteString(h.Render("Actions") + "\n")
+	left.WriteString(k.Render("  Enter       ") + n.Render("open in $EDITOR / activate filter") + "\n")
+	left.WriteString(k.Render("  o           ") + n.Render("read document (glamour)") + "\n")
+	left.WriteString(k.Render("  n           ") + n.Render("new document") + "\n")
+	left.WriteString(k.Render("  s           ") + n.Render("scratch pad") + "\n")
+	left.WriteString(k.Render("  t           ") + n.Render("todo") + "\n")
+	left.WriteString(k.Render("  e           ") + n.Render("export") + "\n")
+	left.WriteString(k.Render("  p           ") + n.Render("pin / unpin") + "\n")
+	left.WriteString(k.Render("  R           ") + n.Render("rescan files & git") + "\n")
+	left.WriteString(k.Render("  Esc         ") + n.Render("clear filter / search") + "\n")
+	left.WriteString(k.Render("  :           ") + n.Render("command mode") + "\n")
+	left.WriteString(k.Render("  q           ") + n.Render("quit") + "\n")
+
+	// Right column: Read Mode, Git Markers.
+	var right strings.Builder
+	right.WriteString(h.Render("Read Mode (o)") + "\n")
+	right.WriteString(k.Render("  j / k       ") + n.Render("scroll line") + "\n")
+	right.WriteString(k.Render("  d / u       ") + n.Render("half page down / up") + "\n")
+	right.WriteString(k.Render("  f / b       ") + n.Render("full page down / up") + "\n")
+	right.WriteString(k.Render("  g / G       ") + n.Render("top / bottom") + "\n")
+	right.WriteString(k.Render("  q / Esc     ") + n.Render("exit read mode") + "\n\n")
+
+	right.WriteString(h.Render("Git Markers") + "\n")
+	right.WriteString(k.Render("  "+m.icons.GitModified+"  ") + n.Render("modified") + "\n")
+	right.WriteString(k.Render("  "+m.icons.GitUntracked+"  ") + n.Render("untracked (new file)") + "\n")
+	right.WriteString(k.Render("  "+m.icons.GitStaged+"  ") + n.Render("staged for commit") + "\n")
+
+	// Lay out two columns side by side.
+	colWidth := (m.width - 6) / 2 // 6 = border(2) + padding(2) + gap(2)
+	if colWidth < 30 {
+		colWidth = 30
+	}
+	leftCol := lipgloss.NewStyle().Width(colWidth).Render(left.String())
+	rightCol := lipgloss.NewStyle().Width(colWidth).Render(right.String())
+	columns := lipgloss.JoinHorizontal(lipgloss.Top, leftCol, "  ", rightCol)
+
 	var b strings.Builder
 	b.WriteString(h.Render("Keybindings") + "\n\n")
-
-	b.WriteString(h.Render("Navigation") + "\n")
-	b.WriteString(k.Render("  j / k       ") + n.Render("move down / up") + "\n")
-	b.WriteString(k.Render("  h / l       ") + n.Render("prev / next panel") + "\n")
-	b.WriteString(k.Render("  gg / G      ") + n.Render("top / bottom") + "\n\n")
-
-	b.WriteString(h.Render("Modes") + "\n")
-	b.WriteString(k.Render("  /           ") + n.Render("search") + "\n")
-	b.WriteString(k.Render("  :           ") + n.Render("command") + "\n")
-	b.WriteString(k.Render("  Esc         ") + n.Render("cancel / return to normal") + "\n\n")
-
-	b.WriteString(h.Render("Panes") + "\n")
-	b.WriteString(k.Render("  1           ") + n.Render("dashboard") + "\n")
-	b.WriteString(k.Render("  2           ") + n.Render("journal") + "\n")
-	b.WriteString(k.Render("  3           ") + n.Render("knowledge base") + "\n")
-	b.WriteString(k.Render("  4           ") + n.Render("tag browser") + "\n")
-	b.WriteString(k.Render("  Tab         ") + n.Render("next pane") + "\n")
-	b.WriteString(k.Render("  Shift+Tab   ") + n.Render("prev pane") + "\n\n")
-
-	b.WriteString(h.Render("Actions") + "\n")
-	b.WriteString(k.Render("  o           ") + n.Render("read document (glamour)") + "\n")
-	b.WriteString(k.Render("  Enter       ") + n.Render("open in $EDITOR") + "\n")
-	b.WriteString(k.Render("  n           ") + n.Render("new document") + "\n")
-	b.WriteString(k.Render("  s           ") + n.Render("scratch pad") + "\n")
-	b.WriteString(k.Render("  t           ") + n.Render("todo") + "\n")
-	b.WriteString(k.Render("  e           ") + n.Render("export") + "\n")
-	b.WriteString(k.Render("  p           ") + n.Render("pin / unpin") + "\n")
-	b.WriteString(k.Render("  R           ") + n.Render("rescan") + "\n")
-	b.WriteString(k.Render("  q           ") + n.Render("quit") + "\n\n")
-
-	b.WriteString(h.Render("Commands (:)") + "\n")
-	b.WriteString(k.Render("  :q / :quit      ") + n.Render("quit") + "\n\n")
-
+	b.WriteString(columns)
+	b.WriteString("\n\n")
 	b.WriteString(m.theme.Muted.Render("Press ? or Esc to close"))
 
 	accentFg := m.theme.Accent.GetForeground()

--- a/tui/view_search.go
+++ b/tui/view_search.go
@@ -1,0 +1,160 @@
+package tui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderSearchPane renders the search pane (View 5) with two columns.
+func (m Model) renderSearchPane() string {
+	var b strings.Builder
+
+	b.WriteString(m.renderTabBar())
+	b.WriteString("\n")
+
+	contentHeight := m.contentHeight()
+
+	leftWidth := m.width / 3
+	rightWidth := m.width - leftWidth - 1
+
+	left := m.renderSearchLeftPanel(leftWidth, contentHeight)
+	right := m.renderSearchDocPanel(rightWidth, contentHeight)
+
+	leftLines := splitLines(left, contentHeight)
+	rightLines := splitLines(right, contentHeight)
+
+	for i := 0; i < contentHeight; i++ {
+		l := ""
+		if i < len(leftLines) {
+			l = leftLines[i]
+		}
+		r := ""
+		if i < len(rightLines) {
+			r = rightLines[i]
+		}
+		b.WriteString(padRight(l, leftWidth))
+		b.WriteString(m.theme.Divider.Render("│"))
+		b.WriteString(r)
+		b.WriteString("\n")
+	}
+
+	b.WriteString(strings.Repeat("─", m.width))
+	b.WriteString("\n")
+	b.WriteString(m.renderStatusBar())
+	return b.String()
+}
+
+// renderSearchLeftPanel renders the search input and category list.
+func (m Model) renderSearchLeftPanel(width, height int) string {
+	focused := m.activePanel == PanelFiles
+	header := styledPanelHeader("Search", focused, width, m.theme, m.icons)
+	var lines []string
+	lines = append(lines, header)
+
+	// Search input row.
+	if m.searchInputFocused {
+		lines = append(lines, " "+m.searchPaneInput.View())
+	} else if m.searchPaneQuery != "" {
+		lines = append(lines, m.theme.Muted.PaddingLeft(1).Render(
+			fmt.Sprintf("filter: %s  (Esc to clear)", m.searchPaneQuery)))
+	} else {
+		lines = append(lines, m.theme.Muted.PaddingLeft(1).Render("Enter to search..."))
+	}
+	lines = append(lines, "") // blank separator
+
+	// Category entries.
+	hasResults := len(m.searchJournalDocs) > 0 || len(m.searchKBDocs) > 0 || len(m.searchTagDocs) > 0
+
+	if !hasResults && m.searchPaneQuery == "" {
+		lines = append(lines, lipgloss.NewStyle().PaddingLeft(1).Render(
+			m.theme.Muted.Render("Type a query and press Enter.")))
+		return strings.Join(lines, "\n")
+	}
+	if !hasResults && m.searchPaneQuery != "" {
+		lines = append(lines, lipgloss.NewStyle().PaddingLeft(1).Render(
+			m.theme.Muted.Render(fmt.Sprintf("No results for %q.", m.searchPaneQuery))))
+		return strings.Join(lines, "\n")
+	}
+
+	type catDef struct {
+		label string
+		count int
+	}
+	cats := []catDef{
+		{"Journal", len(m.searchJournalDocs)},
+		{"KB", len(m.searchKBDocs)},
+		{"Tags", len(m.searchTagDocs)},
+	}
+
+	for i, c := range cats {
+		itemText := fmt.Sprintf(" %s (%d)", c.label, c.count)
+		var line string
+		if i == m.searchCatCursor && focused && !m.searchInputFocused {
+			line = lipgloss.NewStyle().Reverse(true).Width(width).Render(itemText)
+		} else if c.count == 0 {
+			line = m.theme.Muted.Render(itemText)
+		} else {
+			line = m.theme.FileNormal.Render(itemText)
+		}
+		lines = append(lines, line)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderSearchDocPanel renders the documents for the selected search category.
+func (m Model) renderSearchDocPanel(width, height int) string {
+	docFocused := m.activePanel == PanelPreview
+	header := styledPanelHeader("Documents", docFocused, width, m.theme, m.icons)
+	var lines []string
+	lines = append(lines, header)
+
+	docs := m.searchCategoryDocs()
+
+	if len(docs) == 0 {
+		placeholder := "Select a category to see documents."
+		if m.searchPaneQuery != "" {
+			placeholder = "No documents in this category."
+		}
+		lines = append(lines, lipgloss.NewStyle().PaddingTop(1).PaddingLeft(1).Render(
+			m.theme.Muted.Render(placeholder)))
+		return strings.Join(lines, "\n")
+	}
+
+	visibleRows := height - 2
+	start := 0
+	if m.searchDocCursor >= visibleRows {
+		start = m.searchDocCursor - visibleRows + 1
+	}
+
+	for i := start; i < len(docs) && len(lines) < height-1; i++ {
+		d := docs[i]
+		name := d.Frontmatter.Title
+		if name == "" {
+			name = filepath.Base(d.Path)
+		}
+		pinMarker := ""
+		if m.pinnedPaths[d.Path] {
+			pinMarker = " " + m.icons.Pinned
+		}
+		gitMarker := ""
+		if g := m.gitMarkerStyled(d.Path); g != "" {
+			gitMarker = " " + g
+		}
+		markerW := lipgloss.Width(pinMarker) + lipgloss.Width(gitMarker)
+		itemText := " " + truncate(name, width-2-markerW) + pinMarker + gitMarker
+		var line string
+		if i == m.searchDocCursor && docFocused {
+			line = lipgloss.NewStyle().Reverse(true).Width(width).Render(itemText)
+		} else if m.pinnedPaths[d.Path] {
+			line = m.theme.FilePinned.Render(itemText)
+		} else {
+			line = m.theme.FileNormal.Render(itemText)
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/tui/view_search_test.go
+++ b/tui/view_search_test.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	"github.com/AegirAexx/mdam/internal/document"
+	"github.com/AegirAexx/mdam/internal/search"
+)
+
+var searchTestDocs = []search.Result{
+	{
+		Path: "/notes/2026-03-14.md",
+		Frontmatter: document.Frontmatter{
+			Title:    "Journal 2026-03-14",
+			Type:     "journal",
+			Tags:     []string{"daily", "project"},
+			Modified: time.Date(2026, 3, 14, 0, 0, 0, 0, time.UTC),
+		},
+	},
+	{
+		Path: "/notes/setup-nginx.md",
+		Frontmatter: document.Frontmatter{
+			Title:    "Setup Nginx",
+			Type:     "kb",
+			Tags:     []string{"devops"},
+			Modified: time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC),
+		},
+	},
+	{
+		Path: "/notes/kb-go.md",
+		Frontmatter: document.Frontmatter{
+			Title:    "Go Notes",
+			Type:     "kb_language",
+			Tags:     []string{"go", "project"},
+			Modified: time.Date(2026, 3, 12, 0, 0, 0, 0, time.UTC),
+		},
+	},
+}
+
+func TestCategorizeResults(t *testing.T) {
+	journal, kb, tags := categorizeResults(searchTestDocs, "project")
+
+	if len(journal) != 1 {
+		t.Errorf("journal count = %d, want 1", len(journal))
+	}
+	if len(kb) != 2 {
+		t.Errorf("kb count = %d, want 2 (kb + kb_language)", len(kb))
+	}
+	if len(tags) != 2 {
+		t.Errorf("tags count = %d, want 2 (docs with tag matching 'project')", len(tags))
+	}
+}
+
+func TestCategorizeResultsEmpty(t *testing.T) {
+	journal, kb, tags := categorizeResults(nil, "anything")
+	if len(journal) != 0 || len(kb) != 0 || len(tags) != 0 {
+		t.Errorf("empty results: journal=%d, kb=%d, tags=%d, want all 0",
+			len(journal), len(kb), len(tags))
+	}
+}
+
+func TestCategorizeResultsOverlap(t *testing.T) {
+	// A journal doc with a tag matching the query appears in both Journal and Tags.
+	journal, _, tags := categorizeResults(searchTestDocs, "daily")
+	if len(journal) != 1 {
+		t.Errorf("journal count = %d, want 1", len(journal))
+	}
+	if len(tags) != 1 {
+		t.Errorf("tags count = %d, want 1 (daily tag matches 'daily')", len(tags))
+	}
+}
+
+func TestSearchCategoryDocs(t *testing.T) {
+	m := newTestModel()
+	m.searchJournalDocs = searchTestDocs[:1]
+	m.searchKBDocs = searchTestDocs[1:3]
+	m.searchTagDocs = searchTestDocs[2:3]
+
+	tests := []struct {
+		cursor int
+		want   int
+	}{
+		{0, 1}, // journal
+		{1, 2}, // kb
+		{2, 1}, // tags
+	}
+	for _, tt := range tests {
+		m.searchCatCursor = tt.cursor
+		docs := m.searchCategoryDocs()
+		if len(docs) != tt.want {
+			t.Errorf("searchCatCursor=%d: got %d docs, want %d", tt.cursor, len(docs), tt.want)
+		}
+	}
+}
+
+func TestRenderSearchPaneEmptyState(t *testing.T) {
+	m := newTestModel()
+	m.width = 80
+	m.height = 24
+	m.activeView = ViewSearch
+	view := stripANSI(m.renderSearchPane())
+	if view == "" {
+		t.Error("renderSearchPane with no results returned empty string")
+	}
+}

--- a/tui/view_tags.go
+++ b/tui/view_tags.go
@@ -83,21 +83,39 @@ func (m Model) renderTagPanel(width, height int) string {
 	var lines []string
 	lines = append(lines, header)
 
-	if len(m.tagEntries) == 0 {
-		lines = append(lines, lipgloss.NewStyle().PaddingTop(1).PaddingLeft(1).Render(
-			m.theme.Muted.Render("No tags found."),
-		))
+	// Filter input row.
+	if m.tagFilterActive {
+		lines = append(lines, " "+m.tagFilterInput.View())
+	} else if v := m.tagFilterInput.Value(); v != "" {
+		lines = append(lines, m.theme.Muted.PaddingLeft(1).Render(
+			fmt.Sprintf("filter: %s  (Esc to clear)", v)))
+	} else {
+		lines = append(lines, m.theme.Muted.PaddingLeft(1).Render("Enter to filter..."))
+	}
+
+	entries := m.visibleTagEntries()
+
+	if len(entries) == 0 {
+		if m.tagFilterInput.Value() != "" {
+			lines = append(lines, lipgloss.NewStyle().PaddingTop(1).PaddingLeft(1).Render(
+				m.theme.Muted.Render("No matching tags."),
+			))
+		} else {
+			lines = append(lines, lipgloss.NewStyle().PaddingTop(1).PaddingLeft(1).Render(
+				m.theme.Muted.Render("No tags found."),
+			))
+		}
 		return strings.Join(lines, "\n")
 	}
 
-	visibleRows := height - 2
+	visibleRows := height - 3 // header + filter input + bottom margin
 	start := 0
 	if m.tagCursor >= visibleRows {
 		start = m.tagCursor - visibleRows + 1
 	}
 
-	for i := start; i < len(m.tagEntries) && len(lines) < height-1; i++ {
-		te := m.tagEntries[i]
+	for i := start; i < len(entries) && len(lines) < height-1; i++ {
+		te := entries[i]
 		tagName := m.icons.Tag + te.Name
 		countStr := fmt.Sprintf(" (%d)", te.Count)
 		itemText := " " + truncate(tagName, width-len(countStr)-2) + countStr

--- a/tui/view_tags_test.go
+++ b/tui/view_tags_test.go
@@ -113,6 +113,67 @@ func TestTagIndexMsgUpdatesTagEntries(t *testing.T) {
 	}
 }
 
+func TestFilterTagEntries(t *testing.T) {
+	entries := []tagEntry{
+		{Name: "go", Count: 3},
+		{Name: "devops", Count: 2},
+		{Name: "project", Count: 5},
+		{Name: "golang", Count: 1},
+	}
+
+	// "go" should match "go" and "golang" (fuzzy contains).
+	filtered := filterTagEntries(entries, "go")
+	if len(filtered) != 2 {
+		t.Errorf("filterTagEntries('go') = %d entries, want 2", len(filtered))
+	}
+}
+
+func TestFilterTagEntriesEmpty(t *testing.T) {
+	entries := []tagEntry{{Name: "go", Count: 3}}
+	// Empty filter returns all entries.
+	filtered := filterTagEntries(entries, "")
+	if len(filtered) != 1 {
+		t.Errorf("filterTagEntries('') = %d entries, want 1", len(filtered))
+	}
+}
+
+func TestFilterTagEntriesNoMatch(t *testing.T) {
+	entries := []tagEntry{{Name: "go", Count: 3}}
+	filtered := filterTagEntries(entries, "xyz")
+	if len(filtered) != 0 {
+		t.Errorf("filterTagEntries('xyz') = %d entries, want 0", len(filtered))
+	}
+}
+
+func TestVisibleTagEntriesWithFilter(t *testing.T) {
+	m := newTestModel()
+	m.tagEntries = []tagEntry{
+		{Name: "go", Count: 3},
+		{Name: "devops", Count: 2},
+	}
+	m.tagFilterActive = true
+	m.tagFilterInput.SetValue("go")
+	m.tagFilteredEntries = filterTagEntries(m.tagEntries, "go")
+
+	entries := m.visibleTagEntries()
+	if len(entries) != 1 {
+		t.Errorf("visibleTagEntries with filter 'go' = %d, want 1", len(entries))
+	}
+}
+
+func TestVisibleTagEntriesWithoutFilter(t *testing.T) {
+	m := newTestModel()
+	m.tagEntries = []tagEntry{
+		{Name: "go", Count: 3},
+		{Name: "devops", Count: 2},
+	}
+
+	entries := m.visibleTagEntries()
+	if len(entries) != 2 {
+		t.Errorf("visibleTagEntries without filter = %d, want 2", len(entries))
+	}
+}
+
 // fakePinnedDocs are used for dashboard tests.
 var fakePinnedDocs = []search.Result{
 	{


### PR DESCRIPTION
Add Search pane (view 5) with categorized results (Journal/KB/Tags), tag browser substring filter, single-g keybinding, two-column help menu with read mode keys and git marker legend. Remove ModeSearch, gg chord, roadmap, and all forward-looking docs language.