### PR TITLE
Dogfooding round 2: templates, KB paths, read mode, pins, getting-sta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ On first launch, mdam detects no configuration and starts a TUI setup wizard tha
 
 The wizard creates:
 
-- Directory structure: `journal/`, `kb/`, `.templates/`
+- Directory structure: `journal/`, `kb/`, `.templates/`, `.mdam/`
 - Singleton files: `todo.md`, `scratch.md` (at base root)
+- A getting-started KB document in `kb/` covering onboarding and usage
 - Config at `~/.config/mdam/config.yml`
 - Built-in templates: `journal.md`, `kb.md` in `.templates/`
 
-Setup is fully idempotent — re-running won't overwrite existing files.
+Setup is fully idempotent — re-running won't overwrite existing files or templates.
 
 ---
 
@@ -138,7 +139,7 @@ journal:
 | Dashboard | Navigable two-column view: recent journal / pinned / recent docs + glamour-rendered todo.md |
 | Tag browser | All tags with document counts; substring filter to narrow the list; navigate into any tag to see its documents |
 | Read mode | Full-screen glamour-rendered overlay (`o`); vim navigation (`j`/`k`/`d`/`u`/`f`/`b`/`g`/`G`) |
-| Pin / unpin | Bookmark documents (max 10, FIFO eviction); pins persist to `~/.config/mdam/pins.json` (`p`) |
+| Pin / unpin | Bookmark documents (max 10, FIFO eviction); pins persist to `{base_dir}/.mdam/pins.json` (`p`) |
 | Color theming | Five built-in palettes: tokyonight, nord, gruvbox, catppuccin, dracula |
 | Markdown preview | Live glamour-rendered preview in the right panel |
 

--- a/docs/FRONTMATTER.md
+++ b/docs/FRONTMATTER.md
@@ -93,6 +93,22 @@ Caller-supplied variables (e.g. `{{title}}`) are resolved first, then `{{date:FO
 |---|---|
 | `journal` | `{base_dir}/journal/YYYY-MM-DD.md` |
 | `kb` | `{base_dir}/kb/{kebab-title}.md` |
+| `kb_*` | `{base_dir}/kb/{kebab-title}.md` (grouped by subtype in TUI) |
 | `scratch` | `{base_dir}/scratch.md` |
 | `todo` | `{base_dir}/todo.md` |
 | `unsorted` | `{base_dir}/{kebab-title}.md` |
+
+## KB subtypes
+
+All `kb` documents live in `kb/` on disk. The TUI groups them into virtual folders
+based on the `type` field. Use the `kb_` prefix followed by any label:
+
+| `type` field | TUI folder |
+|---|---|
+| `kb` | KB |
+| `kb_summary` | Summary |
+| `kb_cars` | Cars |
+| `kb_home-lab` | Home Lab |
+
+The suffix is title-cased automatically — hyphens and underscores become spaces.
+No configuration or directory creation is needed; just set the `type` field.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,27 +2,32 @@
 
 mdam is a keyboard-driven terminal TUI for managing a personal markdown document tree — journals, knowledge base, scratch notes.
 
-**Current branch:** `feature/search-overhaul`
+**Current branch:** `fix/dogfooding-round-2`
 
 ---
 
 ## Current State
 
-All core features are implemented and working. The application is in active daily use (dogfooding).
+All core features are implemented and working. The application is in active daily use (dogfooding). Second round of dogfooding fixes landed on this branch.
 
 ### What changed this session
-- **Search pane (View 5)** — new dedicated pane replacing the old search mode. Two-column layout: left panel has search input + three category entries (Journal, KB, Tags), right panel shows documents for the selected category. Enter activates the input, Escape clears results.
-- **Tag browser filter** — substring filter input on the Tag Browser left panel. Enter activates, keystrokes narrow the list, Enter again deactivates (keeps filtered list), Escape clears.
-- **`g` keybinding simplified** — `gg` chord replaced with single `g` for jump-to-top in all contexts. `lastKey` chord state removed.
-- **Help menu overhaul** — two-column layout using full viewport width. Added Read Mode keybindings, Git Markers legend, updated all bindings to match current state.
-- **Documentation overhaul** — removed roadmap, future promises, and references to removed features. All docs now reflect current reality.
+
+- **Template overwriting fix** — `WriteBuiltins()` now skips any template file that already exists on disk, never overwriting user customizations.
+- **New default journal template** — Hours, Work Done, Daily Log/Notes, TODO sections.
+- **KB docs saved to correct directory** — `cmdCreateDoc` now uses `tmpl.TemplateType(t.Content)` to extract the document type from template frontmatter instead of `vars["type"]` (which was always empty). KB docs now correctly go to `kb/`.
+- **Read mode off-by-one fix** — Viewport height changed from `height-3` to `height-2`. Also added resize handling for the read viewport on terminal resize.
+- **pins.json moved to `{base_dir}/.mdam/`** — Lives in version control now. `PinsPath()` returns `{BaseDir}/.mdam/pins.json`. Stale pins (deleted files) are auto-pruned on load.
+- **Getting-started KB doc** — `EnsureGettingStarted()` seeds `kb/getting-started-with-mdam.md` on first run. Covers onboarding, frontmatter, directory layout, KB subtypes, templates, keybinding quick reference.
+- **Docs updated** — README, FRONTMATTER.md updated for `.mdam/` dir, pins location, KB subtypes, getting-started doc.
 
 ### Features on ice
+
 - **Full TODO system** — sweep, archive, categories, priorities. `internal/todo` package exists but is not wired to the TUI.
 - **Import/inbox pipeline** — `internal/importer` exists but `.inbox/` not scaffolded. CLI hidden.
 - **Delete feature** — `d` key disabled, delete confirmation flow removed.
 
 ### Five TUI panes
+
 1. Dashboard — journal / pinned / recent + todo.md preview
 2. Journal — month-folder tree
 3. KB — subtype-folder tree
@@ -30,14 +35,18 @@ All core features are implemented and working. The application is in active dail
 5. Search — query input + results categorized by Journal/KB/Tags
 
 ### Git integration
+
 - `internal/git/git.go` — branch, ahead/behind, per-file status via `git` binary
 - Loaded async on: startup, editor return, manual `R`
 - Per-file markers in all views (Journal, KB, Tags, Dashboard, Search)
 
 ### Config
+
 - Fields: editor, author, base_dir, export_dir, theme, nerd_fonts, journal.auto_create
+- Pins now at `{base_dir}/.mdam/pins.json` (was `~/.config/mdam/pins.json`)
 
 ## All tests pass
+
 ```
 go test ./... — PASS
 go vet ./...  — clean

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,9 +127,14 @@ func (c Config) ScratchPath() string {
 	return filepath.Join(c.BaseDir, "scratch.md")
 }
 
+// MdamDir returns the .mdam metadata directory within BaseDir.
+// This directory lives in version control alongside the managed documents.
+func (c Config) MdamDir() string {
+	return filepath.Join(c.BaseDir, ".mdam")
+}
+
 // PinsPath returns the path for the pinned documents file.
-// Stored alongside the config, not in BaseDir, so pins survive BaseDir changes.
+// Stored in {BaseDir}/.mdam/ so pins live in version control.
 func (c Config) PinsPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "mdam", "pins.json")
+	return filepath.Join(c.MdamDir(), "pins.json")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,9 +89,8 @@ func TestNerdFontsDefault(t *testing.T) {
 }
 
 func TestPinsPath(t *testing.T) {
-	home, _ := os.UserHomeDir()
-	cfg := Config{}
-	want := filepath.Join(home, ".config", "mdam", "pins.json")
+	cfg := Config{BaseDir: "/base"}
+	want := filepath.Join("/base", ".mdam", "pins.json")
 	if got := cfg.PinsPath(); got != want {
 		t.Errorf("PinsPath() = %q, want %q", got, want)
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -114,6 +114,7 @@ func ScaffoldDirs(baseDir string) error {
 		filepath.Join(baseDir, "journal"),
 		filepath.Join(baseDir, "kb"),
 		filepath.Join(baseDir, ".templates"),
+		filepath.Join(baseDir, ".mdam"),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil {
@@ -154,6 +155,111 @@ func EnsureTodo(todoPath string) error {
 	content := fmt.Sprintf("---\ntype: todo\ntitle: TODO\ntags: []\ncreated: %s\nmodified: %s\n---\n", now, now)
 	if err := os.WriteFile(todoPath, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("writing todo: %w", err)
+	}
+	return nil
+}
+
+// EnsureGettingStarted creates a getting-started KB document if it doesn't exist.
+func EnsureGettingStarted(kbDir string) error {
+	path := filepath.Join(kbDir, "getting-started-with-mdam.md")
+	if _, err := os.Stat(path); err == nil {
+		return nil // already exists
+	}
+	now := time.Now().UTC().Format("2006-01-02")
+	content := fmt.Sprintf(`---
+type: kb
+title: Getting Started with mdam
+tags: [mdam]
+created: %s
+modified: %s
+---
+
+# Getting Started with mdam
+
+mdam is a keyboard-driven TUI for managing markdown documents — journals,
+knowledge base notes, tasks, and scratch pads. It never edits your documents;
+all editing is delegated to your `+"`$EDITOR`"+`.
+
+## Onboarding
+
+mdam expects every document to have YAML frontmatter with these fields in order:
+
+`+"```"+`yaml
+---
+type: kb
+title: My Note
+tags: []
+created: %s
+modified: %s
+---
+`+"```"+`
+
+**type** must be one of: `+"`journal`"+`, `+"`kb`"+`, `+"`todo`"+`, `+"`scratch`"+`.
+Files without valid frontmatter are skipped by the scanner.
+
+To adapt existing markdown files, add the frontmatter block above to each file
+and place them in the appropriate directory (`+"`journal/`"+` or `+"`kb/`"+`).
+
+## KB Subtypes
+
+All knowledge base documents live in `+"`kb/`"+` on disk, but the TUI groups them
+into virtual folders based on the `+"`type`"+` field in frontmatter. Use the
+`+"`kb_`"+` prefix followed by any label you want:
+
+- `+"`type: kb`"+`            → grouped under **KB** (the default)
+- `+"`type: kb_summary`"+`    → grouped under **Summary**
+- `+"`type: kb_cars`"+`       → grouped under **Cars**
+- `+"`type: kb_home-lab`"+`   → grouped under **Home Lab**
+
+The suffix is title-cased automatically (hyphens and underscores become spaces).
+Each subtype gets its own collapsible folder in the KB pane (Pane 3), so you can
+organise notes into as many categories as you like without touching the filesystem.
+
+To create a new subtype, just set the `+"`type`"+` field in a document's frontmatter —
+no configuration or directory creation needed.
+
+## Directory Layout
+
+- `+"`journal/`"+`    — daily logs, one file per day (YYYY-MM-DD.md)
+- `+"`kb/`"+`         — permanent notes and knowledge (subtype folders are virtual)
+- `+"`todo.md`"+`     — rolling task list (open with **t**)
+- `+"`scratch.md`"+`  — persistent scratch pad (open with **s**)
+- `+"`.templates/`"+` — document templates with variable interpolation
+
+## Templates
+
+Templates live in `+"`.templates/`"+` and use `+"`{{variable}}`"+` placeholders:
+
+- `+"`{{title}}`"+`      — prompted at creation
+- `+"`{{date_short}}`"+` — today's date (YYYY-MM-DD)
+- `+"`{{date:FORMAT}}`"+` — custom Go time format (e.g. `+"`{{date:Monday - January 02 2006}}`"+`)
+- `+"`{{author}}`"+`     — from config
+- `+"`{{tags}}`"+`       — prompted at creation
+
+Press **n** in the TUI to create a document from a template.
+
+## Quick Reference
+
+| Key       | Action                     |
+|-----------|----------------------------|
+| 1–5       | Switch pane                |
+| j / k     | Move down / up             |
+| h / l     | Switch panel / expand tree |
+| Enter     | Open in editor             |
+| o         | Read mode (rendered view)  |
+| t / s     | Open todo / scratch        |
+| n         | New document               |
+| p         | Pin / unpin                |
+| ?         | Help overlay               |
+| q         | Quit                       |
+
+## Deleting This Document
+
+This document is scaffolded on first run. Feel free to delete, modify, or
+expand it — mdam will not recreate it.
+`, now, now, now, now)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("writing getting-started doc: %w", err)
 	}
 	return nil
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -165,18 +165,15 @@ func BuiltinTemplates() map[string]string {
 }
 
 // WriteBuiltins writes built-in templates to the given directory. An existing
-// file is overwritten only when its content differs from the current built-in,
-// so user-customised templates that match the built-in are left alone and
-// stale copies from older versions are updated automatically.
+// file is never overwritten — user customisations are always preserved.
 func WriteBuiltins(dir string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("creating templates directory: %w", err)
 	}
 	for name, content := range BuiltinTemplates() {
 		path := filepath.Join(dir, name+".md")
-		existing, err := os.ReadFile(path)
-		if err == nil && string(existing) == content {
-			continue // already up-to-date
+		if _, err := os.Stat(path); err == nil {
+			continue // already exists — do not overwrite
 		}
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			return fmt.Errorf("writing template %s: %w", name, err)
@@ -195,9 +192,21 @@ modified: {{date_short}}
 
 # {{date:Monday - January 02 2006}}
 
-## Notes
+---
 
-## TODOs
+## Hours
+
+Start - Finish
+
+## Work Done
+
+- placeholder
+
+## Daily Log
+
+### Notes
+
+## TODO
 
 - [ ]
 `

--- a/tui/commands.go
+++ b/tui/commands.go
@@ -60,7 +60,9 @@ func cmdCreateDoc(t tmpl.Template, vars map[string]string, cfg config.Config) te
 		}
 
 		// Determine destination directory by document type.
-		docType := vars["type"]
+		// Type is a literal in the template frontmatter, not a {{variable}},
+		// so we extract it from the template content rather than vars.
+		docType := tmpl.TemplateType(t.Content)
 		var destDir string
 		switch docType {
 		case "journal":

--- a/tui/model.go
+++ b/tui/model.go
@@ -205,6 +205,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.preview.Width = rightWidth
 		m.preview.Height = previewHeight
+		// Resize read viewport if terminal is resized while in read mode.
+		m.readViewport.Width = m.width
+		m.readViewport.Height = m.height - 2
 		return m, nil
 
 	// --- Spinner ---
@@ -755,7 +758,7 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.readReturnView = m.activeView
 				m.readReturnPanel = m.activePanel
 				m.readDocTitle = title
-				m.readViewport = viewport.New(m.width, m.height-3)
+				m.readViewport = viewport.New(m.width, m.height-2)
 				m.mode = ModeRead
 				return m, cmdLoadRead(d.Path, m.theme.GlamourStyle, m.width)
 			}
@@ -774,7 +777,7 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.readReturnView = m.activeView
 				m.readReturnPanel = m.activePanel
 				m.readDocTitle = title
-				m.readViewport = viewport.New(m.width, m.height-3)
+				m.readViewport = viewport.New(m.width, m.height-2)
 				m.mode = ModeRead
 				return m, cmdLoadRead(d.Path, m.theme.GlamourStyle, m.width)
 			}
@@ -786,7 +789,7 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.readReturnView = m.activeView
 			m.readReturnPanel = m.activePanel
 			m.readDocTitle = "TODO"
-			m.readViewport = viewport.New(m.width, m.height-3)
+			m.readViewport = viewport.New(m.width, m.height-2)
 			m.mode = ModeRead
 			return m, cmdLoadRead(m.cfg.TodoPath(), m.theme.GlamourStyle, m.width)
 		}
@@ -803,7 +806,7 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.readReturnView = m.activeView
 				m.readReturnPanel = m.activePanel
 				m.readDocTitle = title
-				m.readViewport = viewport.New(m.width, m.height-3)
+				m.readViewport = viewport.New(m.width, m.height-2)
 				m.mode = ModeRead
 				return m, cmdLoadRead(path, m.theme.GlamourStyle, m.width)
 			}
@@ -814,7 +817,7 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.readReturnView = m.activeView
 			m.readReturnPanel = m.activePanel
 			m.readDocTitle = m.selectedDocTitle()
-			m.readViewport = viewport.New(m.width, m.height-3)
+			m.readViewport = viewport.New(m.width, m.height-2)
 			m.mode = ModeRead
 			return m, cmdLoadRead(path, m.theme.GlamourStyle, m.width)
 		}

--- a/tui/pins.go
+++ b/tui/pins.go
@@ -12,6 +12,7 @@ const maxPins = 10
 // loadPins reads pinned document paths from path.
 // Returns an empty slice (not an error) if the file does not exist.
 // The slice order is the insertion order (oldest first).
+// Stale entries (files that no longer exist on disk) are pruned automatically.
 func loadPins(path string) ([]string, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
@@ -20,11 +21,22 @@ func loadPins(path string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading pins: %w", err)
 	}
-	var paths []string
-	if err := json.Unmarshal(data, &paths); err != nil {
+	var raw []string
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parsing pins: %w", err)
 	}
-	return paths, nil
+	// Prune stale entries whose files no longer exist.
+	live := raw[:0]
+	for _, p := range raw {
+		if _, err := os.Stat(p); err == nil {
+			live = append(live, p)
+		}
+	}
+	if len(live) != len(raw) {
+		// Persist the pruned list so stale entries don't accumulate.
+		_ = savePins(path, live)
+	}
+	return live, nil
 }
 
 // savePins writes the pinned paths to path as a JSON array preserving order.

--- a/tui/pins_test.go
+++ b/tui/pins_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -19,7 +20,16 @@ func TestSaveAndLoadPinsRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "pins.json")
 
-	pins := []string{"/notes/a.md", "/notes/b.md"}
+	// Create real files so the auto-prune doesn't remove them.
+	aPath := filepath.Join(dir, "a.md")
+	bPath := filepath.Join(dir, "b.md")
+	for _, f := range []string{aPath, bPath} {
+		if err := os.WriteFile(f, []byte("test"), 0o644); err != nil {
+			t.Fatalf("creating test file: %v", err)
+		}
+	}
+
+	pins := []string{aPath, bPath}
 	if err := savePins(path, pins); err != nil {
 		t.Fatalf("savePins: %v", err)
 	}
@@ -29,7 +39,7 @@ func TestSaveAndLoadPinsRoundTrip(t *testing.T) {
 		t.Fatalf("loadPins: %v", err)
 	}
 	if len(loaded) != len(pins) {
-		t.Errorf("loaded %d pins, want %d", len(loaded), len(pins))
+		t.Fatalf("loaded %d pins, want %d", len(loaded), len(pins))
 	}
 	for i, p := range pins {
 		if loaded[i] != p {
@@ -83,6 +93,42 @@ func TestTogglePinPreservesOrder(t *testing.T) {
 		if result[i] != p {
 			t.Errorf("result[%d] = %q, want %q", i, result[i], p)
 		}
+	}
+}
+
+func TestLoadPinsPrunesStaleEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pins.json")
+
+	// One real file, one that doesn't exist.
+	realPath := filepath.Join(dir, "real.md")
+	if err := os.WriteFile(realPath, []byte("test"), 0o644); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+	stalePath := filepath.Join(dir, "gone.md")
+
+	if err := savePins(path, []string{realPath, stalePath}); err != nil {
+		t.Fatalf("savePins: %v", err)
+	}
+
+	loaded, err := loadPins(path)
+	if err != nil {
+		t.Fatalf("loadPins: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 pin after prune, got %d", len(loaded))
+	}
+	if loaded[0] != realPath {
+		t.Errorf("expected %q, got %q", realPath, loaded[0])
+	}
+
+	// Verify pruned list was persisted.
+	reloaded, err := loadPins(path)
+	if err != nil {
+		t.Fatalf("loadPins after prune: %v", err)
+	}
+	if len(reloaded) != 1 {
+		t.Errorf("persisted pins should have 1 entry, got %d", len(reloaded))
 	}
 }
 

--- a/tui/view.go
+++ b/tui/view.go
@@ -49,7 +49,7 @@ func (m Model) renderTabBar() string {
 }
 
 // renderReadMode renders the full-screen glamour read overlay.
-// Layout: document title header (1 line) | viewport | status bar (1 line).
+// Layout: document title header (1 line) | viewport (height-2) | status bar (1 line).
 func (m Model) renderReadMode() string {
 	var b strings.Builder
 	title := m.readDocTitle

--- a/tui/wizard.go
+++ b/tui/wizard.go
@@ -440,6 +440,9 @@ func (m WizardModel) writeAndScaffold() error {
 	if err := setup.EnsureTodo(filepath.Join(m.baseDir, "todo.md")); err != nil {
 		return fmt.Errorf("ensuring todo: %w", err)
 	}
+	if err := setup.EnsureGettingStarted(filepath.Join(m.baseDir, "kb")); err != nil {
+		return fmt.Errorf("ensuring getting-started doc: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
…rted doc

Fix six issues found during daily use:

- Never overwrite existing templates on launch (check existence, not content)
- New default journal template with Hours/Work Done/Daily Log/TODO structure
- KB docs now save to kb/ instead of root (extract type from template content)
- Read mode viewport height fix (height-2, not height-3) + resize handling
- Move pins.json from ~/.config/mdam/ to {base_dir}/.mdam/ for version control
- Auto-prune stale pins on load
- Seed getting-started-with-mdam.md KB doc on first run
- Docs updated: README, FRONTMATTER.md, HANDOFF.md