### PR TITLE
Fix KB tree index out of bounds panic on expand/collapse

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,23 +2,17 @@
 
 mdam is a keyboard-driven terminal TUI for managing a personal markdown document tree — journals, knowledge base, scratch notes.
 
-**Current branch:** `fix/dogfooding-round-2`
+**Current branch:** `fix/kb-tree-index-panic`
 
 ---
 
 ## Current State
 
-All core features are implemented and working. The application is in active daily use (dogfooding). Second round of dogfooding fixes landed on this branch.
+All core features are implemented and working. The application is in active daily use (dogfooding). This branch fixes a critical KB tree panic found during dogfooding.
 
 ### What changed this session
 
-- **Template overwriting fix** — `WriteBuiltins()` now skips any template file that already exists on disk, never overwriting user customizations.
-- **New default journal template** — Hours, Work Done, Daily Log/Notes, TODO sections.
-- **KB docs saved to correct directory** — `cmdCreateDoc` now uses `tmpl.TemplateType(t.Content)` to extract the document type from template frontmatter instead of `vars["type"]` (which was always empty). KB docs now correctly go to `kb/`.
-- **Read mode off-by-one fix** — Viewport height changed from `height-3` to `height-2`. Also added resize handling for the read viewport on terminal resize.
-- **pins.json moved to `{base_dir}/.mdam/`** — Lives in version control now. `PinsPath()` returns `{BaseDir}/.mdam/pins.json`. Stale pins (deleted files) are auto-pruned on load.
-- **Getting-started KB doc** — `EnsureGettingStarted()` seeds `kb/getting-started-with-mdam.md` on first run. Covers onboarding, frontmatter, directory layout, KB subtypes, templates, keybinding quick reference.
-- **Docs updated** — README, FRONTMATTER.md updated for `.mdam/` dir, pins location, KB subtypes, getting-started doc.
+- **KB tree index-out-of-bounds panic fix** — Expanding a folder below a large already-expanded folder caused `kbCursor` to go stale (the expand handler collapses all other folders but never relocated the cursor). The next `h` keypress accessed `rows[i]` out of bounds and panicked. Fixed both the `l` handler (rebuild rows and relocate cursor after expand) and the `h` handler (clamp cursor before any slice access). Two new tests in `tui/view_kb_test.go`.
 
 ### Features on ice
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -506,11 +506,25 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				delete(m.kbExpanded, k2)
 			}
 			m.kbExpanded[key] = true
+			// Rebuild and relocate cursor to the expanded folder.
+			rows = buildKBRows(m.docs, m.kbExpanded)
+			for i, r := range rows {
+				if r.isFolder && r.subtype == key {
+					m.kbCursor = i
+					break
+				}
+			}
 		}
 		// File row: l is a no-op (already inside an open folder).
 	case (k == "h" || k == "left") && m.activeView == ViewKB && m.activePanel == PanelFiles:
 		rows := buildKBRows(m.docs, m.kbExpanded)
-		if m.kbCursor < len(rows) && rows[m.kbCursor].isFolder {
+		if m.kbCursor >= len(rows) {
+			m.kbCursor = len(rows) - 1
+		}
+		if m.kbCursor < 0 {
+			break
+		}
+		if rows[m.kbCursor].isFolder {
 			delete(m.kbExpanded, rows[m.kbCursor].subtype)
 		} else {
 			// File row: collapse parent subtype folder and jump cursor to it.

--- a/tui/view_kb_test.go
+++ b/tui/view_kb_test.go
@@ -127,3 +127,84 @@ func TestKBFilePanel(t *testing.T) {
 		t.Errorf("panel missing file title: %q", rendered)
 	}
 }
+
+// TestKBExpandRelocatesCursor verifies that expanding a folder below a large
+// expanded folder relocates kbCursor to the newly-expanded folder, preventing
+// an index-out-of-bounds panic on the next collapse.
+func TestKBExpandRelocatesCursor(t *testing.T) {
+	// Build a doc set where "Summary" has many children and "Vps" has few.
+	var docs []search.Result
+	for i := 0; i < 14; i++ {
+		docs = append(docs, makeKBDoc("kb_summary", string(rune('A'+i)), "/kb/s"+string(rune('a'+i))+".md"))
+	}
+	docs = append(docs, makeKBDoc("kb_vps", "Server1", "/kb/v1.md"))
+	docs = append(docs, makeKBDoc("kb_vps", "Server2", "/kb/v2.md"))
+
+	m := newTestModel()
+	m.width = 80
+	m.height = 24
+	m.docs = docs
+	m.activeView = ViewKB
+	m.activePanel = PanelFiles
+	m.kbExpanded = map[string]bool{"Summary": true}
+
+	// With Summary expanded: row 0 = Summary folder, rows 1-14 = files,
+	// row 15 = Vps folder. Place cursor on Vps.
+	rows := buildKBRows(m.docs, m.kbExpanded)
+	vpsFolderIdx := -1
+	for i, r := range rows {
+		if r.isFolder && r.subtype == "Vps" {
+			vpsFolderIdx = i
+			break
+		}
+	}
+	if vpsFolderIdx < 0 {
+		t.Fatal("Vps folder not found in rows")
+	}
+	m.kbCursor = vpsFolderIdx
+
+	// Expand Vps (collapses Summary, rebuilds list, relocates cursor).
+	m = sendKey(m, "l")
+
+	newRows := buildKBRows(m.docs, m.kbExpanded)
+	if m.kbCursor >= len(newRows) {
+		t.Fatalf("kbCursor %d out of range after expand (len %d)", m.kbCursor, len(newRows))
+	}
+	if !newRows[m.kbCursor].isFolder || newRows[m.kbCursor].subtype != "Vps" {
+		t.Errorf("expected cursor on Vps folder, got %+v", newRows[m.kbCursor])
+	}
+
+	// Collapse via h — must not panic.
+	m = sendKey(m, "h")
+
+	finalRows := buildKBRows(m.docs, m.kbExpanded)
+	if m.kbCursor >= len(finalRows) {
+		t.Fatalf("kbCursor %d out of range after collapse (len %d)", m.kbCursor, len(finalRows))
+	}
+}
+
+// TestKBCollapseClampsStaleCursor verifies that pressing h with a stale
+// (out-of-bounds) kbCursor clamps it instead of panicking.
+func TestKBCollapseClampsStaleCursor(t *testing.T) {
+	docs := []search.Result{
+		makeKBDoc("kb_summary", "Alpha", "/kb/alpha.md"),
+		makeKBDoc("kb", "Base", "/kb/base.md"),
+	}
+
+	m := newTestModel()
+	m.width = 80
+	m.height = 24
+	m.docs = docs
+	m.activeView = ViewKB
+	m.activePanel = PanelFiles
+	m.kbExpanded = map[string]bool{}
+	m.kbCursor = 20 // deliberately stale / out of bounds
+
+	// Must not panic.
+	m = sendKey(m, "h")
+
+	rows := buildKBRows(m.docs, m.kbExpanded)
+	if m.kbCursor < 0 || m.kbCursor >= len(rows) {
+		t.Fatalf("kbCursor %d out of range after clamp (len %d)", m.kbCursor, len(rows))
+	}
+}


### PR DESCRIPTION
Expanding a folder below an already-expanded folder caused kbCursor to go stale — the l handler collapsed all siblings but never relocated the cursor. The h handler then accessed rows out of bounds and panicked.

Fix: rebuild rows and reposition cursor after expand; clamp cursor before any slice access in the collapse handler.