### PR TITLE
fix(pins): store relative paths in pins.json for cross-machine portab…

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -2,35 +2,22 @@
 
 mdam is a keyboard-driven terminal TUI for managing a personal markdown document tree — journals, knowledge base, scratch notes.
 
-**Current branch:** `test/watcher-audit`
+**Current branch:** `fix/document-pins`
 
 ---
 
 ## Current State
 
-All core features are implemented and working. The application is in active daily use (dogfooding). This branch is a test quality pass addressing all 15 actions from the watcher audit (2026-04-08).
+All core features are implemented and working. The application is in active daily use (dogfooding).
 
 ### What changed this session
 
-**Test quality audit** — 15 actions across 9 packages, all resolved:
+**Pin path portability fix** — `pins.json` now stores paths relative to `base_dir` instead of absolute paths. This fixes pins being silently wiped when the document repo is synced across machines with different home directories.
 
-- **ACTION-001** `internal/document` — `Write()` round-trip now verifies Body, Type, Tags, and timestamps, not just Title.
-- **ACTION-002** `internal/document` — `RenderFrontmatter()` round-trip test for `Extra` fields.
-- **ACTION-003** `internal/search` — Direct table-driven tests for `scoreDocument()` and `extractSnippet()`.
-- **ACTION-004** `internal/setup` — `TestEnsureGettingStarted` added (idempotency verified).
-- **ACTION-005** `internal/git` — Tautological `TestIsAvailable` fixed; result now stored and used.
-- **ACTION-006** `internal/todo` — `ReadTasks()` happy-path test with mixed-status tasks.
-- **ACTION-007** `internal/todo` — `ParseTasks()` assertions extended to cover `.Text` field.
-- **ACTION-008** `internal/journal` — `ListByMonth()` now asserts filenames and newest-first order.
-- **ACTION-009** `internal/journal` — `ScaffoldFrontmatter()` now asserts Created/Modified timestamps and empty Tags slice.
-- **ACTION-010** `internal/config` — `TestDefaultConfigPath` and `TestLoadFromInvalidYAML` added.
-- **ACTION-011** `internal/cli` — Functional tests: `TestJournalListCommand`, `TestTodoListCommand` execute real subcommands.
-- **ACTION-012** `internal/importer` — `scaffoldFrontmatter()` now asserts title derivation and non-zero timestamps.
-- **ACTION-013** `tui` — `TestBuildTagIndexTieBreak` verifies alphabetical sort when tag counts are equal.
-- **ACTION-014** `internal/document` — `TestParseFrontmatterTimestamps` verifies year/month/day values.
-- **ACTION-015** `internal/search` — `TestSearchWithBody` snippet now asserts content contains query term.
-
-**Coverage delta:** 64.8% → 65.5% overall. Notable package gains: `cli` 11.3%→25.7%, `config` 75.6%→84.4%, `setup` 73.1%→79.0%, `search` 88.1%→91.1%.
+- `tui/pins.go` — `loadPins` and `savePins` accept a `baseDir` parameter. Save converts absolute → relative via `filepath.Rel`. Load converts relative → absolute via `filepath.Join`. Absolute entries pass through unchanged (backward compat with pre-fix `pins.json` files).
+- `tui/commands.go` — `cmdLoadPins` / `cmdSavePins` thread `baseDir` through.
+- `tui/model.go` — both call sites pass `m.cfg.BaseDir`.
+- `tui/pins_test.go` — existing tests updated; two new tests: `TestSaveAndLoadPinsRelativePaths` (on-disk JSON is relative, round-trip is correct) and `TestLoadPinsAbsolutePathsBackwardCompat` (old absolute-path files load correctly).
 
 ### Features on ice
 
@@ -55,7 +42,7 @@ All core features are implemented and working. The application is in active dail
 ### Config
 
 - Fields: editor, author, base_dir, export_dir, theme, nerd_fonts, journal.auto_create
-- Pins at `{base_dir}/.mdam/pins.json`
+- Pins at `{base_dir}/.mdam/pins.json` (stored as relative paths as of this session)
 
 ## All tests pass
 

--- a/tui/commands.go
+++ b/tui/commands.go
@@ -211,17 +211,17 @@ func cmdLoadPreview(path, glamourStyle string, width int) tea.Cmd {
 }
 
 // cmdLoadPins reads the pinned document paths from pinsPath.
-func cmdLoadPins(pinsPath string) tea.Cmd {
+func cmdLoadPins(pinsPath, baseDir string) tea.Cmd {
 	return func() tea.Msg {
-		pins, err := loadPins(pinsPath)
+		pins, err := loadPins(pinsPath, baseDir)
 		return pinsLoadedMsg{pins: pins, err: err}
 	}
 }
 
 // cmdSavePins writes the pinned paths to pinsPath asynchronously.
-func cmdSavePins(pinsPath string, pins []string) tea.Cmd {
+func cmdSavePins(pinsPath, baseDir string, pins []string) tea.Cmd {
 	return func() tea.Msg {
-		_ = savePins(pinsPath, pins) // errors silently dropped — pins are best-effort
+		_ = savePins(pinsPath, baseDir, pins) // errors silently dropped — pins are best-effort
 		return nil
 	}
 }

--- a/tui/model.go
+++ b/tui/model.go
@@ -184,7 +184,7 @@ func (m Model) Init() tea.Cmd {
 		cmdLoadDocs(m.cfg.BaseDir),
 		cmdLoadDashTodo(m.cfg.TodoPath(), m.theme.GlamourStyle, m.width),
 		cmdLoadGitStatus(m.cfg.BaseDir),
-		cmdLoadPins(m.cfg.PinsPath()),
+		cmdLoadPins(m.cfg.PinsPath(), m.cfg.BaseDir),
 		cmdAutoCreateJournal(m.cfg),
 		cmdTick(),
 	)
@@ -882,7 +882,7 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if selected := m.selectedDoc(); selected != "" {
 			m.pinnedOrder = togglePin(m.pinnedOrder, selected)
 			m.pinnedPaths = pinsToMap(m.pinnedOrder)
-			return m, cmdSavePins(m.cfg.PinsPath(), m.pinnedOrder)
+			return m, cmdSavePins(m.cfg.PinsPath(), m.cfg.BaseDir, m.pinnedOrder)
 		}
 		m.statusMsg = "no document selected"
 

--- a/tui/pins.go
+++ b/tui/pins.go
@@ -4,17 +4,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // maxPins is the maximum number of pinned documents.
 const maxPins = 10
 
-// loadPins reads pinned document paths from path.
+// loadPins reads pinned document paths from pinsPath.
 // Returns an empty slice (not an error) if the file does not exist.
 // The slice order is the insertion order (oldest first).
 // Stale entries (files that no longer exist on disk) are pruned automatically.
-func loadPins(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
+// Stored paths are relative to baseDir; absolute paths are accepted for
+// backward compatibility with existing pins.json files.
+func loadPins(pinsPath, baseDir string) ([]string, error) {
+	data, err := os.ReadFile(pinsPath)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
@@ -27,21 +30,37 @@ func loadPins(path string) ([]string, error) {
 	}
 	// Prune stale entries whose files no longer exist.
 	live := raw[:0]
-	for _, p := range raw {
-		if _, err := os.Stat(p); err == nil {
-			live = append(live, p)
+	for _, stored := range raw {
+		var abs string
+		if filepath.IsAbs(stored) {
+			abs = stored // backward compat: old absolute path
+		} else {
+			abs = filepath.Join(baseDir, stored)
+		}
+		if _, err := os.Stat(abs); err == nil {
+			live = append(live, abs)
 		}
 	}
 	if len(live) != len(raw) {
 		// Persist the pruned list so stale entries don't accumulate.
-		_ = savePins(path, live)
+		_ = savePins(pinsPath, baseDir, live)
 	}
 	return live, nil
 }
 
-// savePins writes the pinned paths to path as a JSON array preserving order.
-func savePins(pinsPath string, pins []string) error {
-	data, err := json.Marshal(pins)
+// savePins writes the pinned paths to pinsPath as a JSON array preserving order.
+// Paths are stored relative to baseDir so that pins.json is portable across machines.
+// Paths outside baseDir are stored as-is (absolute) as a fallback.
+func savePins(pinsPath, baseDir string, pins []string) error {
+	rel := make([]string, len(pins))
+	for i, abs := range pins {
+		r, err := filepath.Rel(baseDir, abs)
+		if err != nil || filepath.IsAbs(r) {
+			r = abs // outside baseDir: store absolute as fallback
+		}
+		rel[i] = r
+	}
+	data, err := json.Marshal(rel)
 	if err != nil {
 		return fmt.Errorf("marshaling pins: %w", err)
 	}

--- a/tui/pins_test.go
+++ b/tui/pins_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLoadPinsMissingFileReturnsEmpty(t *testing.T) {
-	pins, err := loadPins("/does/not/exist/pins.json")
+	pins, err := loadPins("/does/not/exist/pins.json", "/base")
 	if err != nil {
 		t.Fatalf("loadPins missing file: unexpected error: %v", err)
 	}
@@ -30,11 +30,11 @@ func TestSaveAndLoadPinsRoundTrip(t *testing.T) {
 	}
 
 	pins := []string{aPath, bPath}
-	if err := savePins(path, pins); err != nil {
+	if err := savePins(path, dir, pins); err != nil {
 		t.Fatalf("savePins: %v", err)
 	}
 
-	loaded, err := loadPins(path)
+	loaded, err := loadPins(path, dir)
 	if err != nil {
 		t.Fatalf("loadPins: %v", err)
 	}
@@ -45,6 +45,67 @@ func TestSaveAndLoadPinsRoundTrip(t *testing.T) {
 		if loaded[i] != p {
 			t.Errorf("loaded[%d] = %q, want %q", i, loaded[i], p)
 		}
+	}
+}
+
+func TestSaveAndLoadPinsRelativePaths(t *testing.T) {
+	dir := t.TempDir()
+	pinsPath := filepath.Join(dir, "pins.json")
+
+	// Create real files under the base dir.
+	aPath := filepath.Join(dir, "journal", "a.md")
+	if err := os.MkdirAll(filepath.Dir(aPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(aPath, []byte("test"), 0o644); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+
+	if err := savePins(pinsPath, dir, []string{aPath}); err != nil {
+		t.Fatalf("savePins: %v", err)
+	}
+
+	// Verify the on-disk JSON contains a relative path, not an absolute one.
+	raw, err := os.ReadFile(pinsPath)
+	if err != nil {
+		t.Fatalf("reading pins.json: %v", err)
+	}
+	if filepath.IsAbs(string(raw[1 : len(raw)-2])) { // strip surrounding ["..."]
+		t.Errorf("pins.json should store relative path, got: %s", raw)
+	}
+
+	// Confirm load reconstructs the original absolute path.
+	loaded, err := loadPins(pinsPath, dir)
+	if err != nil {
+		t.Fatalf("loadPins: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0] != aPath {
+		t.Errorf("round-trip: got %v, want [%s]", loaded, aPath)
+	}
+}
+
+func TestLoadPinsAbsolutePathsBackwardCompat(t *testing.T) {
+	dir := t.TempDir()
+	pinsPath := filepath.Join(dir, "pins.json")
+
+	// Simulate a pre-migration pins.json with absolute paths.
+	absPath := filepath.Join(dir, "doc.md")
+	if err := os.WriteFile(absPath, []byte("test"), 0o644); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+	// Write absolute path directly to JSON (old format).
+	jsonData := `["` + absPath + `"]`
+	if err := os.WriteFile(pinsPath, []byte(jsonData), 0o644); err != nil {
+		t.Fatalf("writing pins.json: %v", err)
+	}
+
+	// Load should return the absolute path unchanged.
+	loaded, err := loadPins(pinsPath, "/some/other/base")
+	if err != nil {
+		t.Fatalf("loadPins: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0] != absPath {
+		t.Errorf("backward compat: got %v, want [%s]", loaded, absPath)
 	}
 }
 
@@ -107,11 +168,11 @@ func TestLoadPinsPrunesStaleEntries(t *testing.T) {
 	}
 	stalePath := filepath.Join(dir, "gone.md")
 
-	if err := savePins(path, []string{realPath, stalePath}); err != nil {
+	if err := savePins(path, dir, []string{realPath, stalePath}); err != nil {
 		t.Fatalf("savePins: %v", err)
 	}
 
-	loaded, err := loadPins(path)
+	loaded, err := loadPins(path, dir)
 	if err != nil {
 		t.Fatalf("loadPins: %v", err)
 	}
@@ -123,7 +184,7 @@ func TestLoadPinsPrunesStaleEntries(t *testing.T) {
 	}
 
 	// Verify pruned list was persisted.
-	reloaded, err := loadPins(path)
+	reloaded, err := loadPins(path, dir)
 	if err != nil {
 		t.Fatalf("loadPins after prune: %v", err)
 	}


### PR DESCRIPTION
…ility

Absolute paths in pins.json caused silent pin loss when the document repo was synced via git across machines with different home directories — the stale-prune logic on load would remove all pins that didn't exist at the stored absolute path.

loadPins and savePins now accept a baseDir parameter. Save converts absolute paths to relative via filepath.Rel; load converts them back via filepath.Join. Existing pins.json files with absolute paths are accepted transparently (backward compat).